### PR TITLE
Set ESLint warnings to errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,23 +1,27 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
+  "plugins": ["prettier", "@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parserOptions": {
     "sourceType": "module",
     "ecmaVersion": 2021
-  },
-  "plugins": ["prettier", "@typescript-eslint"],
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
-  "rules": {
-    "prettier/prettier": "error",
-    "eqeqeq": "error",
-    "semi": "error",
-    "no-shadow": "error"
   },
   "env": {
     "node": true,
     "browser": true,
     "mocha": true,
     "es6": true
+  },
+  "rules": {
+    "@typescript-eslint/explicit-module-boundary-types": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-unused-vars": "error",
+    "prettier/prettier": "error",
+    "eqeqeq": "error",
+    "semi": "error",
+    "no-shadow": "error"
   },
   "ignorePatterns": ["_site/**"]
 }

--- a/mocha-setup.ts
+++ b/mocha-setup.ts
@@ -1,4 +1,4 @@
 import { h, Fragment } from "preact";
 
-(global as any).h = h;
-(global as any).Fragment = Fragment;
+globalThis.h = h;
+globalThis.Fragment = Fragment;

--- a/typings/@observablehq/plot/index.d.ts
+++ b/typings/@observablehq/plot/index.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "@observablehq/plot" {
   export function plot(args: any): HTMLElement;
   export function ruleY(args: any): any;


### PR DESCRIPTION
**Why**: Because most people ignore warnings, so we should either enforce it or drop them from the configuration.

The approach was to add `error` entries for any in [the plugin's `recommended.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/recommended.ts) set to `warn`.