### PR TITLE
Include prebuilt design system styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login.gov Reporting Dashboard</title>
+    <link rel="stylesheet" href="/node_modules/identity-style-guide/dist/assets/css/styles.css" />
   </head>
   <body>
     <header>

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -1,6 +1,6 @@
-body {
-  font-family: HelveticaNeue, Helvetica, sans-serif;
-}
+@import "/node_modules/identity-style-guide/dist/assets/scss/packages/required";
+
+@include usa-link-style;
 
 .plot text {
   font-size: 10px;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,4 @@
-import "./css/style.css";
-import "../node_modules/identity-style-guide/dist/assets/scss/_styles.scss";
+import "./css/style.scss";
 
 import { render } from "preact";
 import { banner, accordion } from "identity-style-guide";


### PR DESCRIPTION
**Why**: So that the build isn't quite so slow. For additional styling, we can import just the required mixins / functions.