### PR TITLE
Pin chart x-axis domain

### DIFF
--- a/src/daily-auths-report.tsx
+++ b/src/daily-auths-report.tsx
@@ -155,6 +155,9 @@ function DailyAuthsReport(): VNode {
         y: {
           tickFormat: format(".1s"),
         },
+        x: {
+          domain: [start, finish],
+        },
         style: {},
         marks: [
           Plot.ruleY([0]),

--- a/src/daily-auths-report.tsx
+++ b/src/daily-auths-report.tsx
@@ -185,7 +185,7 @@ function DailyAuthsReport(): VNode {
         ],
       })
     );
-  }, [data, ial, agency]);
+  }, [data, ial, agency, start.valueOf(), finish.valueOf()]);
 
   return (
     <div>


### PR DESCRIPTION
**Why**: so that the chart does not truncate to available
dates (aka show empty sections)

| before | after |
| --- | --- |
| <img width="709" alt="Screen Shot 2021-09-14 at 1 02 01 PM" src="https://user-images.githubusercontent.com/458784/133325896-e20899f5-fc29-4a62-8a65-3a1d44893c92.png"> |  <img width="706" alt="Screen Shot 2021-09-14 at 1 01 52 PM" src="https://user-images.githubusercontent.com/458784/133325926-02eb4ea7-b328-4122-8b18-a03d3d81fdb1.png"> |

