### PR TITLE
Show fewer colors on main page, aggregate by agency

### DIFF
--- a/src/daily-auths-report.test.ts
+++ b/src/daily-auths-report.test.ts
@@ -127,9 +127,9 @@ describe("DailyAuthsReport", () => {
         yearMonthDayParse("2021-01-03"),
         "local",
         fetch
-      ).then((results) => {
-        expect(results).to.have.lengthOf(2);
-        results.forEach((result) => {
+      ).then((processed) => {
+        expect(processed).to.have.lengthOf(2);
+        processed.forEach((result) => {
           expect(result).to.have.property("date");
           expect(result.agency, "sets a default agency if missing").to.not.be.undefined;
         });

--- a/src/daily-auths-report.test.ts
+++ b/src/daily-auths-report.test.ts
@@ -2,48 +2,56 @@ import { VNode } from "preact";
 import { expect } from "chai";
 import { utcParse } from "d3-time-format";
 import fetchMock from "fetch-mock";
-import { tabulate, loadData, ProcessedResult } from "./daily-auths-report";
+import { tabulate, tabulateSumByAgency, loadData, ProcessedResult } from "./daily-auths-report";
 import { TableRow } from "./table";
 
 describe("DailyAuthsReport", () => {
   const yearMonthDayParse = utcParse("%Y-%m-%d") as (s: string) => Date;
 
-  describe("#tabulate", () => {
-    const results = [
-      {
-        date: yearMonthDayParse("2021-01-01"),
-        ial: 1,
-        issuer: "issuer1",
-        agency: "agency1",
-        friendly_name: "app1",
-        count: 100,
-      },
-      {
-        date: yearMonthDayParse("2021-01-01"),
-        ial: 2,
-        issuer: "issuer1",
-        agency: "agency1",
-        friendly_name: "app1",
-        count: 1,
-      },
-      {
-        date: yearMonthDayParse("2021-01-01"),
-        ial: 1,
-        issuer: "issuer2",
-        agency: "agency2",
-        friendly_name: "app2",
-        count: 1000,
-      },
-      {
-        date: yearMonthDayParse("2021-01-02"),
-        ial: 1,
-        issuer: "issuer1",
-        agency: "agency1",
-        friendly_name: "app1",
-        count: 111,
-      },
-    ] as ProcessedResult[];
+  const results = [
+    {
+      date: yearMonthDayParse("2021-01-01"),
+      ial: 1,
+      issuer: "issuer1",
+      agency: "agency1",
+      friendly_name: "app1",
+      count: 100,
+    },
+    {
+      date: yearMonthDayParse("2021-01-01"),
+      ial: 2,
+      issuer: "issuer1",
+      agency: "agency1",
+      friendly_name: "app1",
+      count: 1,
+    },
+    {
+      date: yearMonthDayParse("2021-01-01"),
+      ial: 1,
+      issuer: "issuer2",
+      agency: "agency1",
+      friendly_name: "app2",
+      count: 1000,
+    },
+    {
+      date: yearMonthDayParse("2021-01-01"),
+      ial: 1,
+      issuer: "issuer3",
+      agency: "agency2",
+      friendly_name: "app3",
+      count: 555,
+    },
+    {
+      date: yearMonthDayParse("2021-01-02"),
+      ial: 1,
+      issuer: "issuer1",
+      agency: "agency1",
+      friendly_name: "app1",
+      count: 111,
+    },
+  ] as ProcessedResult[];
 
+  describe("#tabulate", () => {
     function simplifyVNodes(body: TableRow[]): (string | number)[][] {
       return body.map(([agency, issuerSpan, ...rest]) => [
         agency,
@@ -63,11 +71,12 @@ describe("DailyAuthsReport", () => {
         "2021-01-02",
         "Total",
       ]);
-      expect(table.body).to.have.lengthOf(3);
+      expect(table.body).to.have.lengthOf(4);
       expect(simplifyVNodes(table.body)).to.deep.equal([
         ["agency1", "issuer1", "1", 100, 111, 211],
         ["agency1", "issuer1", "2", 1, 0, 1],
-        ["agency2", "issuer2", "1", 1000, 0, 1000],
+        ["agency1", "issuer2", "1", 1000, 0, 1000],
+        ["agency2", "issuer3", "1", 555, 0, 555],
       ]);
     });
 
@@ -77,12 +86,28 @@ describe("DailyAuthsReport", () => {
       expect(simplifyVNodes(table.body)).to.deep.equal([
         ["agency1", "issuer1", "1", 100, 111, 211],
         ["agency1", "issuer1", "2", 1, 0, 1],
+        ["agency1", "issuer2", "1", 1000, 0, 1000],
       ]);
     });
     it("filters by ial", () => {
       const table = tabulate(results, undefined, 2);
 
-      expect(simplifyVNodes(table.body)).to.deep.equal([["agency1", "issuer1", "2", 1, 1]]);
+      expect(simplifyVNodes(table.body)).to.deep.equal([
+        ["agency1", "issuer1", "2", 1, 1],
+      ]);
+    });
+  });
+
+  describe("#tabulateSumByAgency", () => {
+    it("builds a table by agency, ial and sums across issuers", () => {
+      const table = tabulateSumByAgency(results, 1);
+
+      expect(table.header).to.deep.eq(["Agency", "IAL", "2021-01-01", "2021-01-02", "Total"]);
+      expect(table.body).to.have.lengthOf(2);
+      expect(table.body).to.deep.equal([
+        ["agency1", "1", 1100, 111, 1211],
+        ["agency2", "1", 555, 0, 555],
+      ]);
     });
   });
 

--- a/src/daily-auths-report.test.ts
+++ b/src/daily-auths-report.test.ts
@@ -92,9 +92,7 @@ describe("DailyAuthsReport", () => {
     it("filters by ial", () => {
       const table = tabulate(results, undefined, 2);
 
-      expect(simplifyVNodes(table.body)).to.deep.equal([
-        ["agency1", "issuer1", "2", 1, 1],
-      ]);
+      expect(simplifyVNodes(table.body)).to.deep.equal([["agency1", "issuer1", "2", 1, 1]]);
     });
   });
 

--- a/src/daily-auths-report.tsx
+++ b/src/daily-auths-report.tsx
@@ -206,10 +206,7 @@ function DailyAuthsReport(): VNode {
                   thresholds: utcDay,
                 },
                 fill: agency ? "friendly_name" : "steelblue",
-                title: (bin: ProcessedResult[]) => {
-                  const d = bin[0];
-                  return d && (agency ? d.friendly_name : d.agency);
-                },
+                title: agency ? (bin: ProcessedResult[]) => bin[0]?.friendly_name : undefined,
                 filter: (d: ProcessedResult) => d.ial === ial && (!agency || d.agency === agency),
               }
             )

--- a/src/daily-auths-report.tsx
+++ b/src/daily-auths-report.tsx
@@ -68,11 +68,11 @@ function loadData(
 const yearMonthDayFormat = utcFormat("%Y-%m-%d");
 
 function tabulate(
-  results: ProcessedResult[],
+  results?: ProcessedResult[],
   filterAgency?: string,
   filterIal?: number
 ): TableData {
-  const filteredResults = results.filter(
+  const filteredResults = (results || []).filter(
     (d) => (!filterAgency || d.agency === filterAgency) && (!filterIal || d.ial === filterIal)
   );
 
@@ -120,8 +120,8 @@ function tabulate(
   };
 }
 
-function tabulateSumByAgency(results: ProcessedResult[], filterIal?: number): TableData {
-  const filteredResults = results.filter((d) => !filterIal || d.ial === filterIal);
+function tabulateSumByAgency(results?: ProcessedResult[], filterIal?: number): TableData {
+  const filteredResults = (results || []).filter((d) => !filterIal || d.ial === filterIal);
 
   const days = Array.from(new Set(filteredResults.map((d) => d.date.valueOf())))
     .sort((a, b) => a - b)
@@ -220,7 +220,7 @@ function DailyAuthsReport(): VNode {
     <div>
       <div className="chart-wrapper" ref={ref} />
       <Table
-        data={agency ? tabulate(data || [], agency, ial) : tabulateSumByAgency(data || [], ial)}
+        data={agency ? tabulate(data, agency, ial) : tabulateSumByAgency(data, ial)}
         numberFormatter={format(",")}
       />
     </div>

--- a/src/daily-auths-report.tsx
+++ b/src/daily-auths-report.tsx
@@ -159,20 +159,30 @@ function plot({
   data,
   agency,
   ial,
+  facetAgency,
 }: {
   start: Date;
   finish: Date;
-  data: ProcessedResult[] | undefined;
-  agency: string | undefined;
+  data?: ProcessedResult[];
+  agency?: string;
   ial: number;
+  facetAgency?: boolean;
 }): HTMLElement {
   return Plot.plot({
+    height: facetAgency ? new Set((data || []).map(d => d.agency)).size * 60 : undefined,
     y: {
       tickFormat: format(".1s"),
     },
     x: {
       domain: [start, finish],
     },
+    facet: facetAgency
+      ? {
+          data: data || [],
+          y: "agency",
+          marginRight: 150,
+        }
+      : undefined,
     style: {},
     marks: [
       Plot.ruleY([0]),
@@ -249,9 +259,15 @@ function DailyAuthsReport(): VNode {
   return (
     <div>
       <PlotComponent
-        plotter={() => plot({ start, finish, data, agency, ial })}
+        plotter={() => plot({ data, ial, agency, start, finish })}
         inputs={[data, ial, agency, start.valueOf(), finish.valueOf()]}
       />
+      {!agency && (
+        <PlotComponent
+          plotter={() => plot({ data, ial, start, finish, facetAgency: true })}
+          inputs={[data, ial, start.valueOf(), finish.valueOf()]}
+        />
+      )}
       <Table
         data={agency ? tabulate(data, agency, ial) : tabulateSumByAgency(data, ial)}
         numberFormatter={format(",")}

--- a/src/daily-auths-report.tsx
+++ b/src/daily-auths-report.tsx
@@ -169,7 +169,7 @@ function plot({
   facetAgency?: boolean;
 }): HTMLElement {
   return Plot.plot({
-    height: facetAgency ? new Set((data || []).map(d => d.agency)).size * 60 : undefined,
+    height: facetAgency ? new Set((data || []).map((d) => d.agency)).size * 60 : undefined,
     y: {
       tickFormat: format(".1s"),
     },


### PR DESCRIPTION
Based on some Slack feedback from @nickttng that there are a lot of colors by default

This turns the "unfiltered" report into one that aggregates by agency, so that selecting agency is more of a drilldown, so it changes the table as well

But now that I look at this, I think I want to keep the aggregation in the table and maybe leave out the color changing

| mode | before | after |
| --- | --- | -- |
| no agency selected | <img width="1048" alt="Screen Shot 2021-09-14 at 3 17 01 PM" src="https://user-images.githubusercontent.com/458784/133341395-3965d570-1247-41c1-a2e0-abe9804f9490.png"> |  <img width="784" alt="Screen Shot 2021-09-14 at 3 16 49 PM" src="https://user-images.githubusercontent.com/458784/133341423-cbff15b5-e462-491c-8f6e-3c0cb55c972e.png"> |
| single agency selected [no change] | <img width="904" alt="Screen Shot 2021-09-14 at 3 17 23 PM" src="https://user-images.githubusercontent.com/458784/133341446-721c842d-1370-43f8-8ab5-e68a6f6cac04.png"> | <img width="909" alt="Screen Shot 2021-09-14 at 3 17 35 PM" src="https://user-images.githubusercontent.com/458784/133341454-03f7d29e-ac4c-4d09-a5b1-848fb353e06e.png"> |

