### PR TITLE
Move report outside of the <form> tag

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,15 +21,14 @@
     "@typescript-eslint/no-unused-vars": "error",
     "import/no-extraneous-dependencies": ["error", { "devDependencies": ["**/*.test.*", "./*"] }],
     "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" }],
-    "react/jsx-filename-extension": ["error", { "extensions": [".tsx"] }],
-    "react/jsx-fragments": "off"
+    "react/jsx-filename-extension": ["error", { "extensions": [".tsx"] }]
   },
   "settings": {
     "import/resolver": "eslint-import-resolver-typescript",
     "react": {
       "pragma": "h",
       "fragment": "Fragment",
-      "version": "16.0"
+      "version": "16.2"
     }
   },
   "ignorePatterns": ["_site/**"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
     "@typescript-eslint/no-unused-vars": "error",
     "import/no-extraneous-dependencies": ["error", { "devDependencies": ["**/*.test.*", "./*"] }],
     "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" }],
-    "react/jsx-filename-extension": ["error", { "extensions": [".tsx"] }]
+    "react/jsx-filename-extension": ["error", { "extensions": [".tsx"] }],
+    "react/jsx-fragments": "off"
   },
   "settings": {
     "import/resolver": "eslint-import-resolver-typescript",

--- a/src/report-filter-controls.tsx
+++ b/src/report-filter-controls.tsx
@@ -88,92 +88,94 @@ function ReportFilterControls({
   }
 
   return (
-    <div className="usa-form">
-      <form ref={formRef} onChange={update}>
-        <div>
-          <label>
-            Start
-            <input
-              type="date"
-              name="start"
-              value={yearMonthDayFormat(start)}
-              className="usa-input"
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Finish
-            <input
-              type="date"
-              name="finish"
-              value={yearMonthDayFormat(finish)}
-              className="usa-input"
-            />
-          </label>
-        </div>
-        <div>
-          <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, -1)}>
-            &larr; Previous Week
-          </button>
-          <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, +1)}>
-            Next Week &rarr;
-          </button>
-        </div>
-        <div>
-          <div className="usa-radio">
-            <input
-              type="radio"
-              id="ial-1"
-              name="ial"
-              value="1"
-              checked={ial === 1}
-              className="usa-radio__input"
-            />
-            <label htmlFor="ial-1" className="usa-radio__label">
-              IAL 1
+    <>
+      <div className="usa-form">
+        <form ref={formRef} onChange={update}>
+          <div>
+            <label>
+              Start
+              <input
+                type="date"
+                name="start"
+                value={yearMonthDayFormat(start)}
+                className="usa-input"
+              />
             </label>
           </div>
-          <div className="usa-radio">
-            <input
-              type="radio"
-              id="ial-2"
-              name="ial"
-              value="2"
-              checked={ial === 2}
-              className="usa-radio__input"
-            />
-            <label htmlFor="ial-2" className="usa-radio__label">
-              IAL2
+          <div>
+            <label>
+              Finish
+              <input
+                type="date"
+                name="finish"
+                value={yearMonthDayFormat(finish)}
+                className="usa-input"
+              />
             </label>
           </div>
-        </div>
-        <div>
-          <label>
-            Agency
-            <select name="agency" className="usa-select">
-              <option value="">All</option>
-              <optgroup label="Agencies">
-                {allAgencies.map((a) => (
-                  <option value={a} selected={a === agency}>
-                    {a}
-                  </option>
-                ))}
-              </optgroup>
-            </select>
-          </label>
-        </div>
-        <div>
-          <a href="?" className="usa-button usa-button--outline">
-            Reset
-          </a>
-        </div>
-        {env !== DEFAULT_ENV && <input type="hidden" name="env" value={env} />}
-      </form>
+          <div>
+            <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, -1)}>
+              &larr; Previous Week
+            </button>
+            <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, +1)}>
+              Next Week &rarr;
+            </button>
+          </div>
+          <div>
+            <div className="usa-radio">
+              <input
+                type="radio"
+                id="ial-1"
+                name="ial"
+                value="1"
+                checked={ial === 1}
+                className="usa-radio__input"
+              />
+              <label htmlFor="ial-1" className="usa-radio__label">
+                IAL 1
+              </label>
+            </div>
+            <div className="usa-radio">
+              <input
+                type="radio"
+                id="ial-2"
+                name="ial"
+                value="2"
+                checked={ial === 2}
+                className="usa-radio__input"
+              />
+              <label htmlFor="ial-2" className="usa-radio__label">
+                IAL2
+              </label>
+            </div>
+          </div>
+          <div>
+            <label>
+              Agency
+              <select name="agency" className="usa-select">
+                <option value="">All</option>
+                <optgroup label="Agencies">
+                  {allAgencies.map((a) => (
+                    <option value={a} selected={a === agency}>
+                      {a}
+                    </option>
+                  ))}
+                </optgroup>
+              </select>
+            </label>
+          </div>
+          <div>
+            <a href="?" className="usa-button usa-button--outline">
+              Reset
+            </a>
+          </div>
+          {env !== DEFAULT_ENV && <input type="hidden" name="env" value={env} />}
+        </form>
+      </div>
       <ReportFilterControlsContext.Provider value={filterControls}>
         {children}
       </ReportFilterControlsContext.Provider>
-    </div>
+    </>
   );
 }
 

--- a/src/report-filter-controls.tsx
+++ b/src/report-filter-controls.tsx
@@ -89,89 +89,87 @@ function ReportFilterControls({
 
   return (
     <>
-      <div className="usa-form">
-        <form ref={formRef} onChange={update}>
-          <div>
-            <label>
-              Start
-              <input
-                type="date"
-                name="start"
-                value={yearMonthDayFormat(start)}
-                className="usa-input"
-              />
+      <form ref={formRef} onChange={update} className="usa-form">
+        <div>
+          <label>
+            Start
+            <input
+              type="date"
+              name="start"
+              value={yearMonthDayFormat(start)}
+              className="usa-input"
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Finish
+            <input
+              type="date"
+              name="finish"
+              value={yearMonthDayFormat(finish)}
+              className="usa-input"
+            />
+          </label>
+        </div>
+        <div>
+          <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, -1)}>
+            &larr; Previous Week
+          </button>
+          <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, +1)}>
+            Next Week &rarr;
+          </button>
+        </div>
+        <div>
+          <div className="usa-radio">
+            <input
+              type="radio"
+              id="ial-1"
+              name="ial"
+              value="1"
+              checked={ial === 1}
+              className="usa-radio__input"
+            />
+            <label htmlFor="ial-1" className="usa-radio__label">
+              IAL 1
             </label>
           </div>
-          <div>
-            <label>
-              Finish
-              <input
-                type="date"
-                name="finish"
-                value={yearMonthDayFormat(finish)}
-                className="usa-input"
-              />
+          <div className="usa-radio">
+            <input
+              type="radio"
+              id="ial-2"
+              name="ial"
+              value="2"
+              checked={ial === 2}
+              className="usa-radio__input"
+            />
+            <label htmlFor="ial-2" className="usa-radio__label">
+              IAL2
             </label>
           </div>
-          <div>
-            <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, -1)}>
-              &larr; Previous Week
-            </button>
-            <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, +1)}>
-              Next Week &rarr;
-            </button>
-          </div>
-          <div>
-            <div className="usa-radio">
-              <input
-                type="radio"
-                id="ial-1"
-                name="ial"
-                value="1"
-                checked={ial === 1}
-                className="usa-radio__input"
-              />
-              <label htmlFor="ial-1" className="usa-radio__label">
-                IAL 1
-              </label>
-            </div>
-            <div className="usa-radio">
-              <input
-                type="radio"
-                id="ial-2"
-                name="ial"
-                value="2"
-                checked={ial === 2}
-                className="usa-radio__input"
-              />
-              <label htmlFor="ial-2" className="usa-radio__label">
-                IAL2
-              </label>
-            </div>
-          </div>
-          <div>
-            <label>
-              Agency
-              <select name="agency" className="usa-select">
-                <option value="">All</option>
-                <optgroup label="Agencies">
-                  {allAgencies.map((a) => (
-                    <option value={a} selected={a === agency}>
-                      {a}
-                    </option>
-                  ))}
-                </optgroup>
-              </select>
-            </label>
-          </div>
-          <div>
-            <a href="?" className="usa-button usa-button--outline">
-              Reset
-            </a>
-          </div>
-          {env !== DEFAULT_ENV && <input type="hidden" name="env" value={env} />}
-        </form>
-      </div>
+        </div>
+        <div>
+          <label>
+            Agency
+            <select name="agency" className="usa-select">
+              <option value="">All</option>
+              <optgroup label="Agencies">
+                {allAgencies.map((a) => (
+                  <option value={a} selected={a === agency}>
+                    {a}
+                  </option>
+                ))}
+              </optgroup>
+            </select>
+          </label>
+        </div>
+        <div>
+          <a href="?" className="usa-button usa-button--outline">
+            Reset
+          </a>
+        </div>
+        {env !== DEFAULT_ENV && <input type="hidden" name="env" value={env} />}
+      </form>
       <ReportFilterControlsContext.Provider value={filterControls}>
         {children}
       </ReportFilterControlsContext.Provider>


### PR DESCRIPTION
**Why**: logically it does not make sense for the
form to contain the plot, and also the form was
limiting the width of the data table


Diff best viewed with [whitespace hidden](https://github.com/18F/identity-reporting/compare/margolis-full-width?w=1)

| before | after |
| --- | --- |
|  <img width="823" alt="Screen Shot 2021-09-14 at 4 56 22 PM" src="https://user-images.githubusercontent.com/458784/133349122-9d4be11a-73d4-438e-abae-147dea85bdc4.png"> | <img width="1214" alt="Screen Shot 2021-09-14 at 4 56 15 PM" src="https://user-images.githubusercontent.com/458784/133349132-fca39134-c3bb-4c66-8f29-20e9b1abf9b5.png"> |

