### PR TITLE
Add responsive resizing of charts

### DIFF
--- a/src/daily-auths-report.tsx
+++ b/src/daily-auths-report.tsx
@@ -1,5 +1,5 @@
-import { VNode, ComponentChildren } from "preact";
-import { useContext, useEffect, useRef, Inputs, useState } from "preact/hooks";
+import { VNode } from "preact";
+import { useContext, useEffect, useRef, useState } from "preact/hooks";
 import { utcDays, utcDay } from "d3-time";
 import * as Plot from "@observablehq/plot";
 import { format } from "d3-format";
@@ -9,6 +9,7 @@ import { group, ascending, rollup } from "d3-array";
 import { ReportFilterControlsContext } from "./report-filter-controls";
 import Table, { TableData } from "./table";
 import { path as reportPath } from "./report";
+import PlotComponent from "./plot";
 
 interface Result {
   count: number;
@@ -209,30 +210,6 @@ function plot({
       ),
     ],
   });
-}
-
-interface PlotComponentProps {
-  inputs: Inputs;
-  plotter: () => HTMLElement;
-  children?: ComponentChildren;
-}
-
-function PlotComponent({ plotter, inputs, children }: PlotComponentProps): VNode {
-  const ref = useRef(null as HTMLDivElement | null);
-
-  useEffect(() => {
-    if (ref?.current?.children[0]) {
-      ref.current.children[0].remove();
-    }
-
-    ref?.current?.appendChild(plotter());
-  }, inputs);
-
-  return (
-    <div className="chart-wrapper" ref={ref}>
-      {children}
-    </div>
-  );
 }
 
 function DailyAuthsReport(): VNode {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -46,7 +46,13 @@ render(
       </nav>
     </header>
     <main>
-      <Routes />
+      <div className="grid-container">
+        <div className="grid-row">
+          <div className="grid-col-auto">
+            <Routes />
+          </div>
+        </div>
+      </div>
     </main>
   </div>,
   document.getElementById("app") as HTMLElement

--- a/src/plot.tsx
+++ b/src/plot.tsx
@@ -1,0 +1,28 @@
+import { ComponentChildren, VNode } from "preact";
+import { useRef, useEffect, Inputs } from "preact/hooks";
+
+interface PlotComponentProps {
+  inputs: Inputs;
+  plotter: () => HTMLElement;
+  children?: ComponentChildren;
+}
+
+function PlotComponent({ plotter, inputs, children }: PlotComponentProps): VNode {
+  const ref = useRef(null as HTMLDivElement | null);
+
+  useEffect(() => {
+    if (ref?.current?.children[0]) {
+      ref.current.children[0].remove();
+    }
+
+    ref?.current?.appendChild(plotter());
+  }, inputs);
+
+  return (
+    <div className="chart-wrapper" ref={ref}>
+      {children}
+    </div>
+  );
+}
+
+export default PlotComponent;

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -15,28 +15,30 @@ interface TableProps {
 function Table({ data, numberFormatter = String }: TableProps): VNode {
   const { header, body } = data;
   return (
-    <table className="usa-table">
-      <thead>
-        <tr>
-          {header.map((head) => (
-            <th>{head}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {body.map((row) => (
+    <div className="usa-table-container--scrollable">
+      <table className="usa-table usa-table--compact">
+        <thead>
           <tr>
-            {row.map((d) =>
-              typeof d === "number" ? (
-                <td className="table-number text-tabular text-right">{numberFormatter(d)}</td>
-              ) : (
-                <td>{d}</td>
-              )
-            )}
+            {header.map((head) => (
+              <th>{head}</th>
+            ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {body.map((row) => (
+            <tr>
+              {row.map((d) =>
+                typeof d === "number" ? (
+                  <td className="table-number text-tabular text-right">{numberFormatter(d)}</td>
+                ) : (
+                  <td>{d}</td>
+                )
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 


### PR DESCRIPTION
Super basic resizing of the table. It relies on preact to collect duplicate events, so maybe there is some additional debouncing we could add to simplify extra renders if we wanted... (or if we did the SVG chart rendering more directly, we could manage the elements do they wouldn't have to be torn down each time... it's fast enough for now and not causing any problems)


~**Next up**: making the table scrollable, it gets cut off when the breakpoints get too small~ (done, 3918f5a15dd77b4dd5b756aece92e1ed6e9c9a49)

| before | after |
| --- | --- |
| <img width="1110" alt="Screen Shot 2021-09-15 at 5 09 28 PM" src="https://user-images.githubusercontent.com/458784/133529136-b02c945a-d0f2-4e6a-83d2-9d4c7a8550db.png"> | <img width="1110" alt="Screen Shot 2021-09-15 at 5 09 44 PM" src="https://user-images.githubusercontent.com/458784/133529143-db6cc2fc-ff62-47d3-8292-6932c9076e4c.png"> |
| | <img width="748" alt="Screen Shot 2021-09-15 at 5 10 01 PM" src="https://user-images.githubusercontent.com/458784/133529151-833642e6-8e65-4165-bf61-b656b5b4c32b.png"> |
| | <img width="471" alt="Screen Shot 2021-09-15 at 5 10 09 PM" src="https://user-images.githubusercontent.com/458784/133529158-6cb053b6-49fd-49f5-b1eb-0a7ba0b87bc5.png"> |
