### PR TITLE
Update tick formats on chart

### DIFF
--- a/src/daily-auths-report.test.ts
+++ b/src/daily-auths-report.test.ts
@@ -2,7 +2,13 @@ import { VNode } from "preact";
 import { expect } from "chai";
 import { utcParse } from "d3-time-format";
 import fetchMock from "fetch-mock";
-import { tabulate, tabulateSumByAgency, loadData, ProcessedResult } from "./daily-auths-report";
+import {
+  tabulate,
+  tabulateSumByAgency,
+  loadData,
+  formatSIDropTrailingZeroes,
+  ProcessedResult,
+} from "./daily-auths-report";
 import { TableRow } from "./table";
 
 describe("DailyAuthsReport", () => {
@@ -137,5 +143,15 @@ describe("DailyAuthsReport", () => {
     });
 
     after(() => fetchMock.restore());
+  });
+
+  describe("#formatSIDropTrailingZeroes", () => {
+    it("formats with an SI prefix", () => {
+      expect(formatSIDropTrailingZeroes(1_230_000)).to.eq("1.2M");
+    });
+
+    it("drops trailing zeroes", () => {
+      expect(formatSIDropTrailingZeroes(1_000.0)).to.eq("1k");
+    });
   });
 });

--- a/src/daily-auths-report.tsx
+++ b/src/daily-auths-report.tsx
@@ -153,6 +153,9 @@ function tabulateSumByAgency(results?: ProcessedResult[], filterIal?: number): T
   };
 }
 
+const formatSIPrefix = format(".2s");
+const formatSIDropTrailingZeroes = (d: number): string => formatSIPrefix(d).replace(/\.0+/, "");
+
 function plot({
   start,
   finish,
@@ -171,7 +174,7 @@ function plot({
   return Plot.plot({
     height: facetAgency ? new Set((data || []).map((d) => d.agency)).size * 60 : undefined,
     y: {
-      tickFormat: format(".1s"),
+      tickFormat: formatSIDropTrailingZeroes,
     },
     x: {
       domain: [start, finish],
@@ -277,4 +280,4 @@ function DailyAuthsReport(): VNode {
 }
 
 export default DailyAuthsReport;
-export { tabulate, tabulateSumByAgency, loadData };
+export { tabulate, tabulateSumByAgency, loadData, formatSIDropTrailingZeroes };


### PR DESCRIPTION
- Add an extra significant figure
- Drop ".0" because "0.0" is redundant

For the most part d3-format's [SI prefix](https://github.com/d3/d3-format#api-reference) works, but converts "0" to "0.0" which looks really weird on graphs, especially when we only have whole-number auths in this case.

| notes | screenshot |
| --- | --- |
| before, 1 sig fig, has redundant breaks | <img width="469" alt="Screen Shot 2021-09-15 at 6 53 31 PM" src="https://user-images.githubusercontent.com/458784/133538912-14ed6c85-b30b-4225-9369-638f37c3b209.png"> |
| in progress, 2 sig figs, has "0.0" | <img width="469" alt="Screen Shot 2021-09-15 at 6 53 40 PM" src="https://user-images.githubusercontent.com/458784/133538936-61210bc7-4a1e-43af-8fff-e96800a652fa.png"> |
| final product, 2 sig figs except drops trailing zeroes |  <img width="469" alt="Screen Shot 2021-09-15 at 6 53 52 PM" src="https://user-images.githubusercontent.com/458784/133538978-b92fc71b-a67a-448b-b655-0848183d5609.png"> |



