### PR TITLE
Fix images rendered by application

### DIFF
--- a/bin/generate-routes.js
+++ b/bin/generate-routes.js
@@ -1,9 +1,8 @@
 import { mkdir, copyFile } from "fs/promises";
 import { join } from "path";
-import { ROUTES } from "../src/routes";
 
 Promise.all(
-  Object.keys(ROUTES).map(async (path) => {
+  ["/daily-auths-report/"].map(async (path) => {
     const dir = join("_site", path);
     await mkdir(dir, { recursive: true });
     await copyFile("_site/index.html", join(dir, "index.html"));

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -1,0 +1,50 @@
+import { VNode } from "preact";
+import logoURL from "../node_modules/identity-style-guide/dist/assets/img/login-gov-logo.svg";
+import closeURL from "../node_modules/identity-style-guide/dist/assets/img/close.svg";
+import { Link } from "./router";
+
+interface HeaderProps {
+  path: string;
+}
+
+function Header({ path }: HeaderProps): VNode {
+  return (
+    <header className="usa-header usa-header--extended">
+      <div className="usa-navbar">
+        <div className="usa-logo">
+          <Link href="/" title="Home" aria-label="Home">
+            <img src={logoURL} className="usa-logo__img" alt="Login.gov" />
+            <em className="usa-logo__text">Data</em>
+          </Link>
+        </div>
+        <button className="usa-menu-btn" type="button">
+          Menu
+        </button>
+      </div>
+      <nav className="usa-nav">
+        <div className="usa-nav__inner">
+          <button className="usa-nav__close" type="button">
+            <img src={closeURL} alt="Close" />
+          </button>
+          <ul className="usa-nav__primary usa-accordion">
+            <li className="usa-nav__primary-item">
+              <Link href="/" className={path === "/" ? "usa-current" : undefined}>
+                Home
+              </Link>
+            </li>
+            <li className="usa-nav__primary-item">
+              <Link
+                href="/daily-auths-report/"
+                className={path === "/daily-auths-report/" ? "usa-current" : undefined}
+              >
+                Daily Auths Report
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -1,7 +1,7 @@
 import { VNode } from "preact";
 import logoURL from "../node_modules/identity-style-guide/dist/assets/img/login-gov-logo.svg";
 import closeURL from "../node_modules/identity-style-guide/dist/assets/img/close.svg";
-import { Link } from "./router";
+import { getFullPath, Link } from "./router";
 
 interface HeaderProps {
   path: string;
@@ -28,14 +28,14 @@ function Header({ path }: HeaderProps): VNode {
           </button>
           <ul className="usa-nav__primary usa-accordion">
             <li className="usa-nav__primary-item">
-              <Link href="/" className={path === "/" ? "usa-current" : undefined}>
+              <Link href="/" className={path === getFullPath("/") ? "usa-current" : undefined}>
                 Home
               </Link>
             </li>
             <li className="usa-nav__primary-item">
               <Link
                 href="/daily-auths-report/"
-                className={path === "/daily-auths-report/" ? "usa-current" : undefined}
+                className={path === getFullPath("/daily-auths-report/") ? "usa-current" : undefined}
               >
                 Daily Auths Report
               </Link>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,52 +2,8 @@ import "./css/style.scss";
 
 import { render } from "preact";
 import { banner, accordion, navigation } from "identity-style-guide";
-import { Link } from "./router";
 import { Routes } from "./routes";
 
 [banner, accordion, navigation].forEach((component) => component.on());
 
-render(
-  <div>
-    <header className="usa-header usa-header--extended">
-      <div className="usa-navbar">
-        <div className="usa-logo">
-          <Link href="/" title="Home" aria-label="Home">
-            <img
-              src="/node_modules/identity-style-guide/dist/assets/img/login-gov-logo.svg"
-              className="usa-logo__img"
-              alt="Login.gov"
-            />
-            <em className="usa-logo__text">Data</em>
-          </Link>
-        </div>
-        <button className="usa-menu-btn" type="button">
-          Menu
-        </button>
-      </div>
-      <nav className="usa-nav">
-        <div className="usa-nav__inner">
-          <button className="usa-nav__close" type="button">
-            <img src="/node_modules/identity-style-guide/dist/assets/img/close.svg" alt="Close" />
-          </button>
-          <ul className="usa-nav__primary usa-accordion">
-            <li className="usa-nav__primary-item">
-              <Link href="/" activeClassName="usa-current">
-                Home
-              </Link>
-            </li>
-            <li className="usa-nav__primary-item">
-              <Link href="/daily-auths-report/" activeClassName="usa-current">
-                Daily Auths Report
-              </Link>
-            </li>
-          </ul>
-        </div>
-      </nav>
-    </header>
-    <main>
-      <Routes />
-    </main>
-  </div>,
-  document.getElementById("app") as HTMLElement
-);
+render(<Routes />, document.getElementById("app") as HTMLElement);

--- a/src/page.tsx
+++ b/src/page.tsx
@@ -1,0 +1,20 @@
+import { ComponentChildren, VNode } from "preact";
+import Header from "./header";
+
+interface PageProps {
+  path: string;
+  children?: ComponentChildren;
+  title: string;
+}
+
+function Page({ path, children, title }: PageProps): VNode {
+  return (
+    <>
+      <Header path={path} />
+      <h1>{title}</h1>
+      <main>{children}</main>
+    </>
+  );
+}
+
+export default Page;

--- a/src/routes/home-route.tsx
+++ b/src/routes/home-route.tsx
@@ -1,0 +1,14 @@
+import { VNode } from "preact";
+import Page from "../page";
+
+export interface HomeRouteProps {
+  path: string;
+}
+
+function HomeRoute(props: HomeRouteProps): VNode {
+  const { path } = props;
+
+  return <Page path={path} title="Home" />;
+}
+
+export default HomeRoute;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,9 +1,11 @@
 import { VNode } from "preact";
 import { Router } from "../router";
-import ReportRoute from "./report";
+import HomeRoute from "./home-route";
+import ReportRoute from "./report-route";
 
 export const ROUTES = {
   "/daily-auths-report/": ReportRoute,
+  "/": HomeRoute,
 };
 
 export function Routes(): VNode {

--- a/src/routes/report-route.tsx
+++ b/src/routes/report-route.tsx
@@ -1,6 +1,7 @@
 import { VNode } from "preact";
 import DailyAuthsReport from "../daily-auths-report";
 import ReportFilterControls from "../report-filter-controls";
+import Page from "../page";
 
 export interface ReportRouteProps {
   path: string;
@@ -12,10 +13,14 @@ export interface ReportRouteProps {
 }
 
 function ReportRoute(props: ReportRouteProps): VNode {
+  const { path } = props;
+
   return (
-    <ReportFilterControls {...props}>
-      <DailyAuthsReport />
-    </ReportFilterControls>
+    <Page path={path} title="Daily Auths Report">
+      <ReportFilterControls {...props}>
+        <DailyAuthsReport />
+      </ReportFilterControls>
+    </Page>
   );
 }
 

--- a/typings/identity-style-guide/index.d.ts
+++ b/typings/identity-style-guide/index.d.ts
@@ -1,3 +1,5 @@
+declare module "*.svg";
+
 declare module "identity-style-guide" {
   interface Component {
     on: () => void;


### PR DESCRIPTION
**Why**: Vite requires static assets to be imported. It works locally only because node_modules exists in the working directly. But this folder is not created in the built environments.