### PR TITLE
Dropoffs Report Updates

### DIFF
--- a/src/components/daily-dropoffs-report.tsx
+++ b/src/components/daily-dropoffs-report.tsx
@@ -5,7 +5,7 @@ import { scaleLinear, scaleOrdinal } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
 import Markdown from "preact-markdown";
 import { ascending } from "d3-array";
-import { ReportFilterContext } from "../contexts/report-filter-context";
+import { FunnelMode, ReportFilterContext } from "../contexts/report-filter-context";
 import Table, { TableData } from "./table";
 import { useAgencies } from "../contexts/agencies-context";
 import Accordion from "./accordion";
@@ -13,7 +13,6 @@ import useResizeListener from "../hooks/resize-listener";
 import DailyDropoffsLineChart from "./daily-dropoffs-line-chart";
 import {
   DailyDropoffsRow,
-  FunnelMode,
   funnelSteps,
   loadData,
   toStepCounts,
@@ -91,7 +90,7 @@ function tabulate({
 function DailyDropffsReport(): VNode {
   const ref = useRef(null as HTMLDivElement | null);
   const [width, setWidth] = useState(undefined as number | undefined);
-  const { start, finish, agency, env, funnelMode } = useContext(ReportFilterContext);
+  const { start, finish, agency, env, funnelMode, scale } = useContext(ReportFilterContext);
 
   const { data } = useQuery(`dropoffs/${start.valueOf()}-${finish.valueOf()}`, () =>
     loadData(start, finish, env)
@@ -129,6 +128,7 @@ The data model table can't accurately capture:
         width={width}
         color={issuerColor}
         funnelMode={funnelMode}
+        scale={scale}
       />
       <Table
         data={tabulate({ rows: filteredData, issuerColor, funnelMode })}

--- a/src/components/page.tsx
+++ b/src/components/page.tsx
@@ -13,7 +13,7 @@ function Page({ path, children, title }: PageProps): VNode {
       <Header path={path} />
       <div className="grid-container">
         <div className="grid-row">
-          <div className="grid-col-auto">
+          <div className="grid-col-fill">
             <h1>{title}</h1>
             <main>{children}</main>
           </div>

--- a/src/components/report-filter-controls.tsx
+++ b/src/components/report-filter-controls.tsx
@@ -62,7 +62,7 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
               <fieldset className="usa-fieldset">
                 <legend className="usa-legend">Time Range</legend>
                 <div>
-                  <label>
+                  <label className="usa-label">
                     Start
                     <input
                       type="date"
@@ -73,7 +73,7 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                   </label>
                 </div>
                 <div>
-                  <label>
+                  <label className="usa-label">
                     Finish
                     <input
                       type="date"
@@ -129,7 +129,7 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={ial === 1}
                       className="usa-radio__input"
                     />
-                    <label htmlFor="ial-1" className="usa-radio__label">
+                    <label htmlFor="ial-1" className="usa-label usa-radio__label">
                       IAL 1
                     </label>
                   </div>
@@ -142,7 +142,7 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={ial === 2}
                       className="usa-radio__input"
                     />
-                    <label htmlFor="ial-2" className="usa-radio__label">
+                    <label htmlFor="ial-2" className="usa-label usa-radio__label">
                       IAL2
                     </label>
                   </div>
@@ -160,7 +160,10 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={funnelMode === FunnelMode.OVERALL}
                       className="usa-radio__input"
                     />
-                    <label htmlFor="funnel-mode-overall" className="usa-radio__label">
+                    <label
+                      htmlFor="funnel-mode-overall"
+                      className="usa-label usa-radio__label"
+                    >
                       Overall
                     </label>
                   </div>
@@ -173,7 +176,10 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={funnelMode === FunnelMode.BLANKET}
                       className="usa-radio__input"
                     />
-                    <label htmlFor="funnel-mode-blanket" className="usa-radio__label">
+                    <label
+                      htmlFor="funnel-mode-blanket"
+                      className="usa-label usa-radio__label"
+                    >
                       Blanket
                     </label>
                   </div>
@@ -191,7 +197,7 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={scale === Scale.COUNT}
                       className="usa-radio__input"
                     />
-                    <label htmlFor="scale-count" className="usa-radio__label">
+                    <label htmlFor="scale-count" className="usa-label usa-radio__label">
                       Count
                     </label>
                   </div>
@@ -204,7 +210,10 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={scale === Scale.PERCENT}
                       className="usa-radio__input"
                     />
-                    <label htmlFor="scale-percent" className="usa-radio__label">
+                    <label
+                      htmlFor="scale-percent"
+                      className="usa-label usa-radio__label"
+                    >
                       Percent
                     </label>
                   </div>

--- a/src/components/report-filter-controls.tsx
+++ b/src/components/report-filter-controls.tsx
@@ -160,10 +160,7 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={funnelMode === FunnelMode.OVERALL}
                       className="usa-radio__input"
                     />
-                    <label
-                      htmlFor="funnel-mode-overall"
-                      className="usa-label usa-radio__label"
-                    >
+                    <label htmlFor="funnel-mode-overall" className="usa-label usa-radio__label">
                       Overall
                     </label>
                   </div>
@@ -176,10 +173,7 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={funnelMode === FunnelMode.BLANKET}
                       className="usa-radio__input"
                     />
-                    <label
-                      htmlFor="funnel-mode-blanket"
-                      className="usa-label usa-radio__label"
-                    >
+                    <label htmlFor="funnel-mode-blanket" className="usa-label usa-radio__label">
                       Blanket
                     </label>
                   </div>
@@ -210,10 +204,7 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       checked={scale === Scale.PERCENT}
                       className="usa-radio__input"
                     />
-                    <label
-                      htmlFor="scale-percent"
-                      className="usa-label usa-radio__label"
-                    >
+                    <label htmlFor="scale-percent" className="usa-label usa-radio__label">
                       Percent
                     </label>
                   </div>

--- a/src/components/report-filter-controls.tsx
+++ b/src/components/report-filter-controls.tsx
@@ -55,149 +55,172 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
 
   return (
     <>
-      <form ref={formRef} onChange={update} className="usa-form">
-        <div>
-          <label>
-            Start
-            <input
-              type="date"
-              name="start"
-              value={yearMonthDayFormat(start)}
-              className="usa-input"
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Finish
-            <input
-              type="date"
-              name="finish"
-              value={yearMonthDayFormat(finish)}
-              className="usa-input"
-            />
-          </label>
-        </div>
-        <div>
-          <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, -1)}>
-            &larr; Previous Week
-          </button>
-          <button type="button" className="usa-button" onClick={updateTimeRange(utcWeek, +1)}>
-            Next Week &rarr;
-          </button>
-        </div>
-        {controls?.includes(Control.IAL) && (
-          <fieldset className="usa-fieldset">
-            <legend className="usa-legend">IAL</legend>
-            <div className="usa-radio">
-              <input
-                type="radio"
-                id="ial-1"
-                name="ial"
-                value="1"
-                checked={ial === 1}
-                className="usa-radio__input"
-              />
-              <label htmlFor="ial-1" className="usa-radio__label">
-                IAL 1
-              </label>
+      <form ref={formRef} onChange={update} className="usa-form-full-width">
+        <div className="grid-container padding-0">
+          <div className="grid-row grid-gap">
+            <div className="tablet:grid-col-6">
+              <fieldset className="usa-fieldset">
+                <legend className="usa-legend">Time Range</legend>
+                <div>
+                  <label>
+                    Start
+                    <input
+                      type="date"
+                      name="start"
+                      value={yearMonthDayFormat(start)}
+                      className="usa-input"
+                    />
+                  </label>
+                </div>
+                <div>
+                  <label>
+                    Finish
+                    <input
+                      type="date"
+                      name="finish"
+                      value={yearMonthDayFormat(finish)}
+                      className="usa-input"
+                    />
+                  </label>
+                </div>
+                <div className="margin-top-2">
+                  <button
+                    type="button"
+                    className="usa-button"
+                    onClick={updateTimeRange(utcWeek, -1)}
+                  >
+                    &larr; Previous Week
+                  </button>
+                  <button
+                    type="button"
+                    className="usa-button"
+                    onClick={updateTimeRange(utcWeek, +1)}
+                  >
+                    Next Week &rarr;
+                  </button>
+                </div>
+              </fieldset>
+              <fieldset className="usa-fieldset">
+                <legend className="usa-legend" id="agency-legend">
+                  Agency
+                </legend>
+                <select name="agency" className="usa-select" aria-labelledby="agency-legend">
+                  <option value="">All</option>
+                  <optgroup label="Agencies">
+                    {agencies.map((a) => (
+                      <option value={a} selected={a === agency}>
+                        {a}
+                      </option>
+                    ))}
+                  </optgroup>
+                </select>
+              </fieldset>
             </div>
-            <div className="usa-radio">
-              <input
-                type="radio"
-                id="ial-2"
-                name="ial"
-                value="2"
-                checked={ial === 2}
-                className="usa-radio__input"
-              />
-              <label htmlFor="ial-2" className="usa-radio__label">
-                IAL2
-              </label>
+            <div className="tablet:grid-col-6">
+              {controls?.includes(Control.IAL) && (
+                <fieldset className="usa-fieldset">
+                  <legend className="usa-legend">IAL</legend>
+                  <div className="usa-radio">
+                    <input
+                      type="radio"
+                      id="ial-1"
+                      name="ial"
+                      value="1"
+                      checked={ial === 1}
+                      className="usa-radio__input"
+                    />
+                    <label htmlFor="ial-1" className="usa-radio__label">
+                      IAL 1
+                    </label>
+                  </div>
+                  <div className="usa-radio">
+                    <input
+                      type="radio"
+                      id="ial-2"
+                      name="ial"
+                      value="2"
+                      checked={ial === 2}
+                      className="usa-radio__input"
+                    />
+                    <label htmlFor="ial-2" className="usa-radio__label">
+                      IAL2
+                    </label>
+                  </div>
+                </fieldset>
+              )}
+              {controls?.includes(Control.FUNNEL_MODE) && (
+                <fieldset className="usa-fieldset">
+                  <legend className="usa-legend">Funnel Mode</legend>
+                  <div className="usa-radio">
+                    <input
+                      type="radio"
+                      id="funnel-mode-overall"
+                      name="funnelMode"
+                      value={FunnelMode.OVERALL}
+                      checked={funnelMode === FunnelMode.OVERALL}
+                      className="usa-radio__input"
+                    />
+                    <label htmlFor="funnel-mode-overall" className="usa-radio__label">
+                      Overall
+                    </label>
+                  </div>
+                  <div className="usa-radio">
+                    <input
+                      type="radio"
+                      id="funnel-mode-blanket"
+                      name="funnelMode"
+                      value={FunnelMode.BLANKET}
+                      checked={funnelMode === FunnelMode.BLANKET}
+                      className="usa-radio__input"
+                    />
+                    <label htmlFor="funnel-mode-blanket" className="usa-radio__label">
+                      Blanket
+                    </label>
+                  </div>
+                </fieldset>
+              )}
+              {controls?.includes(Control.SCALE) && (
+                <fieldset className="usa-fieldset">
+                  <legend className="usa-legend">Scale</legend>
+                  <div className="usa-radio">
+                    <input
+                      type="radio"
+                      id="scale-count"
+                      name="scale"
+                      value={Scale.COUNT}
+                      checked={scale === Scale.COUNT}
+                      className="usa-radio__input"
+                    />
+                    <label htmlFor="scale-count" className="usa-radio__label">
+                      Count
+                    </label>
+                  </div>
+                  <div className="usa-radio">
+                    <input
+                      type="radio"
+                      id="scale-percent"
+                      name="scale"
+                      value={Scale.PERCENT}
+                      checked={scale === Scale.PERCENT}
+                      className="usa-radio__input"
+                    />
+                    <label htmlFor="scale-percent" className="usa-radio__label">
+                      Percent
+                    </label>
+                  </div>
+                </fieldset>
+              )}
             </div>
-          </fieldset>
-        )}
-        {controls?.includes(Control.FUNNEL_MODE) && (
-          <fieldset className="usa-fieldset">
-            <legend className="usa-legend">Funnel Mode</legend>
-            <div className="usa-radio">
-              <input
-                type="radio"
-                id="funnel-mode-overall"
-                name="funnelMode"
-                value={FunnelMode.OVERALL}
-                checked={funnelMode === FunnelMode.OVERALL}
-                className="usa-radio__input"
-              />
-              <label htmlFor="funnel-mode-overall" className="usa-radio__label">
-                Overall
-              </label>
+          </div>
+          <div className="grid-row margin-top-2">
+            <div className="tablet:grid-col-6">
+              <div>
+                <a href="?" className="usa-button usa-button--outline">
+                  Reset
+                </a>
+              </div>
             </div>
-            <div className="usa-radio">
-              <input
-                type="radio"
-                id="funnel-mode-blanket"
-                name="funnelMode"
-                value={FunnelMode.BLANKET}
-                checked={funnelMode === FunnelMode.BLANKET}
-                className="usa-radio__input"
-              />
-              <label htmlFor="funnel-mode-blanket" className="usa-radio__label">
-                Blanket
-              </label>
-            </div>
-          </fieldset>
-        )}
-        {controls?.includes(Control.SCALE) && (
-          <fieldset className="usa-fieldset">
-            <legend className="usa-legend">Scale</legend>
-            <div className="usa-radio">
-              <input
-                type="radio"
-                id="scale-count"
-                name="scale"
-                value={Scale.COUNT}
-                checked={scale === Scale.COUNT}
-                className="usa-radio__input"
-              />
-              <label htmlFor="scale-count" className="usa-radio__label">
-                Count
-              </label>
-            </div>
-            <div className="usa-radio">
-              <input
-                type="radio"
-                id="scale-percent"
-                name="scale"
-                value={Scale.PERCENT}
-                checked={scale === Scale.PERCENT}
-                className="usa-radio__input"
-              />
-              <label htmlFor="scale-percent" className="usa-radio__label">
-                Percent
-              </label>
-            </div>
-          </fieldset>
-        )}
-        <div>
-          <label>
-            Agency
-            <select name="agency" className="usa-select">
-              <option value="">All</option>
-              <optgroup label="Agencies">
-                {agencies.map((a) => (
-                  <option value={a} selected={a === agency}>
-                    {a}
-                  </option>
-                ))}
-              </optgroup>
-            </select>
-          </label>
-        </div>
-        <div>
-          <a href="?" className="usa-button usa-button--outline">
-            Reset
-          </a>
+          </div>
         </div>
         {env !== DEFAULT_ENV && <input type="hidden" name="env" value={env} />}
       </form>

--- a/src/components/report-filter-controls.tsx
+++ b/src/components/report-filter-controls.tsx
@@ -3,21 +3,30 @@ import { useRef, useContext } from "preact/hooks";
 import { utcFormat } from "d3-time-format";
 import { utcWeek, CountableTimeInterval } from "d3-time";
 import { AgenciesContext } from "../contexts/agencies-context";
-import { ReportFilterContext, DEFAULT_ENV } from "../contexts/report-filter-context";
-import { FunnelMode } from "../models/daily-dropoffs-report-data";
+import {
+  ReportFilterContext,
+  DEFAULT_ENV,
+  Scale,
+  FunnelMode,
+} from "../contexts/report-filter-context";
 
 const yearMonthDayFormat = utcFormat("%Y-%m-%d");
 
-interface ReportFilterControlsProps {
-  showIal: boolean;
-  showFunnelMode: boolean;
+/**
+ * Controls on the form that can be opted into
+ */
+enum Control {
+  IAL = "ial",
+  FUNNEL_MODE = "funnel_mode",
+  SCALE = "scale",
 }
 
-function ReportFilterControls({
-  showIal = false,
-  showFunnelMode = false,
-}: ReportFilterControlsProps): VNode {
-  const { start, finish, agency, ial, env, funnelMode, setParameters } =
+interface ReportFilterControlsProps {
+  controls?: Control[];
+}
+
+function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
+  const { start, finish, agency, ial, env, funnelMode, scale, setParameters } =
     useContext(ReportFilterContext);
   const { agencies } = useContext(AgenciesContext);
 
@@ -77,7 +86,7 @@ function ReportFilterControls({
             Next Week &rarr;
           </button>
         </div>
-        {showIal && (
+        {controls?.includes(Control.IAL) && (
           <fieldset className="usa-fieldset">
             <legend className="usa-legend">IAL</legend>
             <div className="usa-radio">
@@ -108,7 +117,7 @@ function ReportFilterControls({
             </div>
           </fieldset>
         )}
-        {showFunnelMode && (
+        {controls?.includes(Control.FUNNEL_MODE) && (
           <fieldset className="usa-fieldset">
             <legend className="usa-legend">Funnel Mode</legend>
             <div className="usa-radio">
@@ -135,6 +144,37 @@ function ReportFilterControls({
               />
               <label htmlFor="funnel-mode-blanket" className="usa-radio__label">
                 Blanket
+              </label>
+            </div>
+          </fieldset>
+        )}
+        {controls?.includes(Control.SCALE) && (
+          <fieldset className="usa-fieldset">
+            <legend className="usa-legend">Scale</legend>
+            <div className="usa-radio">
+              <input
+                type="radio"
+                id="scale-count"
+                name="scale"
+                value={Scale.COUNT}
+                checked={scale === Scale.COUNT}
+                className="usa-radio__input"
+              />
+              <label htmlFor="scale-count" className="usa-radio__label">
+                Count
+              </label>
+            </div>
+            <div className="usa-radio">
+              <input
+                type="radio"
+                id="scale-percent"
+                name="scale"
+                value={Scale.PERCENT}
+                checked={scale === Scale.PERCENT}
+                className="usa-radio__input"
+              />
+              <label htmlFor="scale-percent" className="usa-radio__label">
+                Percent
               </label>
             </div>
           </fieldset>
@@ -166,4 +206,4 @@ function ReportFilterControls({
 }
 
 export default ReportFilterControls;
-export { ReportFilterControlsProps };
+export { ReportFilterControlsProps, Control };

--- a/src/contexts/report-filter-context.tsx
+++ b/src/contexts/report-filter-context.tsx
@@ -1,9 +1,26 @@
 import { createContext, VNode, ComponentChildren } from "preact";
-import { DEFAULT_FUNNEL_MODE, FunnelMode } from "../models/daily-dropoffs-report-data";
 import { route } from "../router";
+
+enum Scale {
+  COUNT = "count",
+  PERCENT = "percent",
+}
+
+enum FunnelMode {
+  /**
+   * Starts funnel at the welcome screen
+   */
+  OVERALL = "overall",
+  /**
+   * Starts funnel at the image submission screen
+   */
+  BLANKET = "blanket",
+}
 
 const DEFAULT_IAL = 1;
 const DEFAULT_ENV = "prod";
+const DEFAULT_SCALE = Scale.COUNT;
+const DEFAULT_FUNNEL_MODE = FunnelMode.OVERALL;
 
 interface ReportFilterContextValues {
   start: Date;
@@ -12,6 +29,7 @@ interface ReportFilterContextValues {
   agency?: string;
   env: string;
   funnelMode: FunnelMode;
+  scale: Scale;
   setParameters: (params: Record<string, string>) => void;
 }
 
@@ -38,6 +56,7 @@ const ReportFilterContext = createContext({
   env: DEFAULT_ENV,
   setParameters: defaultSetParameters,
   funnelMode: DEFAULT_FUNNEL_MODE,
+  scale: DEFAULT_SCALE,
 } as ReportFilterContextValues);
 
 type ReportFilterContextProviderProps = Omit<ReportFilterContextValues, "setParameters">;
@@ -54,4 +73,12 @@ function ReportFilterContextProvider({
 }
 
 export default ReportFilterContextProvider;
-export { ReportFilterContext, DEFAULT_IAL, DEFAULT_ENV };
+export {
+  ReportFilterContext,
+  Scale,
+  FunnelMode,
+  DEFAULT_IAL,
+  DEFAULT_ENV,
+  DEFAULT_SCALE,
+  DEFAULT_FUNNEL_MODE,
+};

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -17,3 +17,10 @@
     text-anchor: start;
   }
 }
+
+/**
+ * Default usa-form is limited to 20rem aka one column
+ */
+.usa-form-full-width {
+  @include u-width(full);
+}

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -21,6 +21,6 @@
 /**
  * Default usa-form is limited to 20rem aka one column
  */
-.usa-form-full-width {
+.usa-form--full-width {
   @include u-width(full);
 }

--- a/src/models/daily-dropoffs-report-data.test.ts
+++ b/src/models/daily-dropoffs-report-data.test.ts
@@ -7,8 +7,8 @@ import {
   aggregate,
   loadData,
   toStepCounts,
-  FunnelMode,
 } from "./daily-dropoffs-report-data";
+import { FunnelMode } from "../contexts/report-filter-context";
 
 describe("DailyDropoffsReportData", () => {
   describe("#aggregate", () => {

--- a/src/models/daily-dropoffs-report-data.ts
+++ b/src/models/daily-dropoffs-report-data.ts
@@ -2,19 +2,7 @@ import { group, ascending } from "d3-array";
 import { csvParse, autoType } from "d3-dsv";
 import { utcDays } from "d3-time";
 import { path as reportPath } from "./api-path";
-
-enum FunnelMode {
-  /**
-   * Starts funnel at the welcome screen
-   */
-  OVERALL = "overall",
-  /**
-   * Starts funnel at the image submission screen
-   */
-  BLANKET = "blanket",
-}
-
-const DEFAULT_FUNNEL_MODE = FunnelMode.OVERALL;
+import { FunnelMode } from "../contexts/report-filter-context";
 
 enum Step {
   WELCOME = "welcome",
@@ -157,8 +145,6 @@ function loadData(
 }
 
 export {
-  FunnelMode,
-  DEFAULT_FUNNEL_MODE,
   DailyDropoffsRow,
   Step,
   StepCount,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { VNode } from "preact";
+import { Control } from "../components/report-filter-controls";
 import DailyAuthsReport from "../components/daily-auths-report";
 import DailyDropffsReport from "../components/daily-dropoffs-report";
 import { Router } from "../router";
@@ -8,11 +9,11 @@ import createReportRoute from "./report-route";
 export const ROUTES = {
   "/daily-auths-report/": createReportRoute(DailyAuthsReport, {
     title: "Daily Auths Report",
-    filterOpts: { showIal: true, showFunnelMode: false },
+    controls: [Control.IAL],
   }),
   "/daily-dropoffs-report/": createReportRoute(DailyDropffsReport, {
     title: "Daily Dropoffs Report",
-    filterOpts: { showIal: false, showFunnelMode: true },
+    controls: [Control.FUNNEL_MODE, Control.SCALE],
   }),
   "/": HomeRoute,
 };

--- a/src/routes/report-route.tsx
+++ b/src/routes/report-route.tsx
@@ -5,12 +5,13 @@ import { AgenciesContextProvider } from "../contexts/agencies-context";
 import ReportFilterContextProvider, {
   DEFAULT_IAL,
   DEFAULT_ENV,
+  Scale,
+  DEFAULT_SCALE,
+  DEFAULT_FUNNEL_MODE,
+  FunnelMode,
 } from "../contexts/report-filter-context";
-import ReportFilterControls, {
-  ReportFilterControlsProps,
-} from "../components/report-filter-controls";
+import ReportFilterControls, { Control } from "../components/report-filter-controls";
 import Page from "../components/page";
-import { DEFAULT_FUNNEL_MODE, FunnelMode } from "../models/daily-dropoffs-report-data";
 
 const yearMonthDayParse = utcParse("%Y-%m-%d");
 
@@ -22,16 +23,17 @@ export interface ReportRouteProps {
   agency?: string;
   env?: string;
   funnelMode?: FunnelMode;
+  scale?: Scale;
 }
 
 function createReportRoute(
   Report: () => VNode,
   {
     title,
-    filterOpts,
+    controls,
   }: {
     title: string;
-    filterOpts: ReportFilterControlsProps;
+    controls?: Control[];
   }
 ): (props: ReportRouteProps) => VNode {
   return ({
@@ -42,6 +44,7 @@ function createReportRoute(
     agency,
     env: envParam,
     funnelMode: funnelModeParam,
+    scale: scaleParam,
   }: ReportRouteProps): VNode => {
     const endOfPreviousWeek = utcWeek.floor(new Date());
     const startOfPreviousWeek = utcWeek.floor(new Date(endOfPreviousWeek.valueOf() - 1));
@@ -51,6 +54,7 @@ function createReportRoute(
     const ial = (parseInt(ialParam || "", 10) || DEFAULT_IAL) as 1 | 2;
     const env = envParam || DEFAULT_ENV;
     const funnelMode = funnelModeParam || DEFAULT_FUNNEL_MODE;
+    const scale = scaleParam || DEFAULT_SCALE;
 
     return (
       <Page path={path} title={title}>
@@ -62,8 +66,9 @@ function createReportRoute(
             agency={agency}
             env={env}
             funnelMode={funnelMode}
+            scale={scale}
           >
-            <ReportFilterControls {...filterOpts} />
+            <ReportFilterControls controls={controls} />
             <Report />
           </ReportFilterContextProvider>
         </AgenciesContextProvider>


### PR DESCRIPTION
(builds on #32 for organization)

Updates!
1. The table on the dropoffs reports page now filters down by agency, sorts by agency then app friendly name
2. The chart on the dropoffs report can switch between counts and percents, makes it easier to compare across apps with different scales:

| count | percent |
| --- | --- |
| <img width="907" alt="Screen Shot 2021-09-24 at 9 52 10 AM" src="https://user-images.githubusercontent.com/458784/134714143-56059143-b943-40cf-bbd4-3d58692bdd38.png"> | <img width="907" alt="Screen Shot 2021-09-24 at 9 52 03 AM" src="https://user-images.githubusercontent.com/458784/134714164-dd129a6f-f9dc-4e96-b6e6-0b8ee4099936.png"> | 