### PR TITLE
Switch dropoff funnel terminology

### DIFF
--- a/src/components/daily-dropoffs-report.tsx
+++ b/src/components/daily-dropoffs-report.tsx
@@ -108,11 +108,6 @@ function DailyDropffsReport(): VNode {
       <Accordion title="How is this measured?">
         <Markdown
           markdown={`
-**Definitions**:
-
-- *Blanket*: The funnel starts at the image submit step
-- *Overall*: The funnel starts at the welcome step
-
 **Timing**: All data is collected, grouped, and displayed in the UTC timezone.
 
 **Known Limitations**:

--- a/src/components/report-filter-controls.tsx
+++ b/src/components/report-filter-controls.tsx
@@ -154,19 +154,6 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                   <div className="usa-radio">
                     <input
                       type="radio"
-                      id="funnel-mode-overall"
-                      name="funnelMode"
-                      value={FunnelMode.OVERALL}
-                      checked={funnelMode === FunnelMode.OVERALL}
-                      className="usa-radio__input"
-                    />
-                    <label htmlFor="funnel-mode-overall" className="usa-label usa-radio__label">
-                      Overall
-                    </label>
-                  </div>
-                  <div className="usa-radio">
-                    <input
-                      type="radio"
                       id="funnel-mode-blanket"
                       name="funnelMode"
                       value={FunnelMode.BLANKET}
@@ -176,6 +163,21 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                     <label htmlFor="funnel-mode-blanket" className="usa-label usa-radio__label">
                       Blanket
                     </label>
+                    <span className="margin-left-1">The funnel starts at the welcome step</span>
+                  </div>
+                  <div className="usa-radio">
+                    <input
+                      type="radio"
+                      id="funnel-mode-actual"
+                      name="funnelMode"
+                      value={FunnelMode.ACTUAL}
+                      checked={funnelMode === FunnelMode.ACTUAL}
+                      className="usa-radio__input"
+                    />
+                    <label htmlFor="funnel-mode-actual" className="usa-label usa-radio__label">
+                      Actual
+                    </label>
+                    <span className="margin-left-1">The funnel starts at the image submit step</span>
                   </div>
                 </fieldset>
               )}

--- a/src/components/report-filter-controls.tsx
+++ b/src/components/report-filter-controls.tsx
@@ -177,7 +177,9 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                     <label htmlFor="funnel-mode-actual" className="usa-label usa-radio__label">
                       Actual
                     </label>
-                    <span className="margin-left-1">The funnel starts at the image submit step</span>
+                    <span className="margin-left-1">
+                      The funnel starts at the image submit step
+                    </span>
                   </div>
                 </fieldset>
               )}

--- a/src/components/report-filter-controls.tsx
+++ b/src/components/report-filter-controls.tsx
@@ -159,11 +159,14 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       value={FunnelMode.BLANKET}
                       checked={funnelMode === FunnelMode.BLANKET}
                       className="usa-radio__input"
+                      aria-describedby="funnel-mode-blanket-desc"
                     />
                     <label htmlFor="funnel-mode-blanket" className="usa-label usa-radio__label">
                       Blanket
                     </label>
-                    <span className="margin-left-1">The funnel starts at the welcome step</span>
+                    <span className="margin-left-1" id="funnel-mode-blanket-desc">
+                      The funnel starts at the welcome step
+                    </span>
                   </div>
                   <div className="usa-radio">
                     <input
@@ -173,11 +176,12 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
                       value={FunnelMode.ACTUAL}
                       checked={funnelMode === FunnelMode.ACTUAL}
                       className="usa-radio__input"
+                      aria-describedby="funnel-mode-actual-desc"
                     />
                     <label htmlFor="funnel-mode-actual" className="usa-label usa-radio__label">
                       Actual
                     </label>
-                    <span className="margin-left-1">
+                    <span className="margin-left-1" id="funnel-mode-actual-desc">
                       The funnel starts at the image submit step
                     </span>
                   </div>

--- a/src/contexts/report-filter-context.tsx
+++ b/src/contexts/report-filter-context.tsx
@@ -8,19 +8,19 @@ enum Scale {
 
 enum FunnelMode {
   /**
-   * Starts funnel at the welcome screen
-   */
-  OVERALL = "overall",
-  /**
-   * Starts funnel at the image submission screen
+   * The funnel starts at the welcome step
    */
   BLANKET = "blanket",
+  /**
+   * The funnel starts at the image submit step
+   */
+  ACTUAL = "actual",
 }
 
 const DEFAULT_IAL = 1;
 const DEFAULT_ENV = "prod";
 const DEFAULT_SCALE = Scale.COUNT;
-const DEFAULT_FUNNEL_MODE = FunnelMode.OVERALL;
+const DEFAULT_FUNNEL_MODE = FunnelMode.BLANKET;
 
 interface ReportFilterContextValues {
   start: Date;

--- a/src/models/daily-dropoffs-report-data.test.ts
+++ b/src/models/daily-dropoffs-report-data.test.ts
@@ -152,7 +152,7 @@ issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+
     };
 
     it("converts a single row into an array of steps with counts and percents", () => {
-      expect(toStepCounts(row, FunnelMode.OVERALL)).to.deep.equal([
+      expect(toStepCounts(row, FunnelMode.BLANKET)).to.deep.equal([
         { step: Step.WELCOME, count: 1e10, percentOfFirst: 1, percentOfPrevious: 1 },
         { step: Step.AGREEMENT, count: 1e9, percentOfFirst: 0.1, percentOfPrevious: 0.1 },
         { step: Step.CAPTURE_DOCUMENT, count: 1e8, percentOfFirst: 0.01, percentOfPrevious: 0.1 },
@@ -168,7 +168,7 @@ issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+
     });
 
     it("starts at the image submit step for BLANKET mode", () => {
-      expect(toStepCounts(row, FunnelMode.BLANKET)).to.deep.equal([
+      expect(toStepCounts(row, FunnelMode.ACTUAL)).to.deep.equal([
         { step: Step.CAP_DOC_SUBMIT, count: 1e7, percentOfFirst: 1, percentOfPrevious: 1 },
         { step: Step.SSN, count: 1e6, percentOfFirst: 0.1, percentOfPrevious: 0.1 },
         { step: Step.VERIFY_INFO, count: 1e5, percentOfFirst: 0.01, percentOfPrevious: 0.1 },

--- a/src/models/daily-dropoffs-report-data.test.ts
+++ b/src/models/daily-dropoffs-report-data.test.ts
@@ -167,7 +167,7 @@ issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+
       ]);
     });
 
-    it("starts at the image submit step for BLANKET mode", () => {
+    it("starts at the image submit step for ACTUAL mode", () => {
       expect(toStepCounts(row, FunnelMode.ACTUAL)).to.deep.equal([
         { step: Step.CAP_DOC_SUBMIT, count: 1e7, percentOfFirst: 1, percentOfPrevious: 1 },
         { step: Step.SSN, count: 1e6, percentOfFirst: 0.1, percentOfPrevious: 0.1 },

--- a/src/models/daily-dropoffs-report-data.ts
+++ b/src/models/daily-dropoffs-report-data.ts
@@ -64,7 +64,7 @@ function process(str: string): DailyDropoffsRow[] {
 }
 
 function funnelSteps(funnelMode: FunnelMode): StepTitle[] {
-  return funnelMode === FunnelMode.OVERALL ? STEPS : STEPS.slice(3);
+  return funnelMode === FunnelMode.BLANKET ? STEPS : STEPS.slice(3);
 }
 
 interface StepCount {


### PR DESCRIPTION
I got these wrong, so this corrects that, see [notes from grace coworking](https://docs.google.com/document/d/1zGFmLGZpzuJ6ld71V0sMhIpiF01qNAg1thMvZrGkAG0/edit#)

  | Old Name | New Name | Defintion                   |
  | -------- | -------- | --------------------------- |
  | overall  | blanket  | starts at welcome step      |
  | blanket  | actual   | starts at image submit step |

I also figured the definitions could live in the form instead of the explanation accordion:

| before | after |
| --- | --- |
| <img width="451" alt="Screen Shot 2021-09-29 at 11 06 07 AM" src="https://user-images.githubusercontent.com/458784/135324510-399493b4-1747-4553-811b-3d2e80394f63.png"> | <img width="429" alt="Screen Shot 2021-09-29 at 11 02 25 AM" src="https://user-images.githubusercontent.com/458784/135324439-7a071365-d525-40e0-bc9f-096171d7f1cc.png">|



