### PR TITLE
Fix Daily Auths Report plot to match table

### DIFF
--- a/src/components/daily-auths-report.test.ts
+++ b/src/components/daily-auths-report.test.ts
@@ -77,21 +77,6 @@ describe("DailyAuthsReport", () => {
         ["agency2", "issuer3", "1", 555, 0, 555],
       ]);
     });
-
-    it("filters by agency", () => {
-      const table = tabulate({ results, filterAgency: "agency1" });
-
-      expect(simplifyVNodes(table.body)).to.deep.equal([
-        ["agency1", "issuer1", "1", 100, 111, 211],
-        ["agency1", "issuer1", "2", 1, 0, 1],
-        ["agency1", "issuer2", "1", 1000, 0, 1000],
-      ]);
-    });
-    it("filters by ial", () => {
-      const table = tabulate({ results, filterIal: 2 });
-
-      expect(simplifyVNodes(table.body)).to.deep.equal([["agency1", "issuer1", "2", 1, 1]]);
-    });
   });
 
   describe("#tabulateSumByAgency", () => {
@@ -103,12 +88,13 @@ describe("DailyAuthsReport", () => {
     }
 
     it("builds a table by agency, ial and sums across issuers", () => {
-      const table = tabulateSumByAgency({ results, filterIal: 1, setParameters: () => null });
+      const table = tabulateSumByAgency({ results, setParameters: () => null });
 
       expect(table.header).to.deep.eq(["Agency", "IAL", "2021-01-01", "2021-01-02", "Total"]);
-      expect(table.body).to.have.lengthOf(2);
+      expect(table.body).to.have.lengthOf(3);
       expect(simplifyVNodes(table.body)).to.deep.equal([
         ["agency1", "1", 1100, 111, 1211],
+        ["agency1", "2", 1, 0, 1],
         ["agency2", "1", 555, 0, 555],
       ]);
     });

--- a/src/components/daily-auths-report.tsx
+++ b/src/components/daily-auths-report.tsx
@@ -62,13 +62,14 @@ function plot({
               value: "date",
               thresholds: utcDay,
             },
-            fill: agency ? "friendly_name" : "steelblue",
+            fill: agency ? "issuer" : "steelblue",
             title: (bin: ProcessedResult[]) => {
               const date = yearMonthDayFormat(bin[0].date);
               const total = formatWithCommas(bin.reduce((sum, d) => sum + d.count, 0));
-              const friendlyName = bin[0]?.friendly_name;
+              const friendlyName = bin[0].friendly_name;
+              const issuer = bin[0].issuer;
 
-              return [agency && `${friendlyName}:`, total, `(${date})`].filter(Boolean).join(" ");
+              return [agency && `${friendlyName}:`, total, `(${date})`, issuer].filter(Boolean).join(" ");
             },
             filter: (d: ProcessedResult) => d.ial === ial && (!agency || d.agency === agency),
           }
@@ -108,7 +109,9 @@ function tabulate({ results }: { results: ProcessedResult[] }): TableData {
 
             return [
               agency,
-              <span title={issuer}>{issuerToFriendlyName.get(issuer)}</span>,
+              <td className="max-width-300 truncate-ellipsis" title={issuer}>
+                {issuerToFriendlyName.get(issuer)} <small>({issuer})</small>
+              </td>,
               String(ial),
               ...dayCounts,
               dayCounts.reduce((d, total) => d + total, 0),

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -24,3 +24,13 @@
 .usa-form--full-width {
   @include u-width(full);
 }
+
+.max-width-300 {
+  max-width: 300px;
+}
+
+.truncate-ellipsis {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Problem:
- plot was grouping by "friendly_name" which is not unique
- table was grouping by issuer, which is unique
This meant that sometimes the numbers on the plot would not match numbers in the table, now they do

Also shows issuer on table but truncates it

| before | after |
| --- | --- |
| <img width="755" alt="Screen Shot 2021-09-29 at 12 50 52 PM" src="https://user-images.githubusercontent.com/458784/135339181-5ef2ab22-ab27-4e8c-a324-a603793f3c39.png"> |  <img width="755" alt="Screen Shot 2021-09-29 at 12 52 04 PM" src="https://user-images.githubusercontent.com/458784/135339195-7d9c6d68-bd26-4d61-b750-a470547e03c6.png"> |

