### PR TITLE
Move date controls into a 2-column layout

### DIFF
--- a/src/components/report-filter-controls.tsx
+++ b/src/components/report-filter-controls.tsx
@@ -61,43 +61,49 @@ function ReportFilterControls({ controls }: ReportFilterControlsProps): VNode {
             <div className="tablet:grid-col-6">
               <fieldset className="usa-fieldset">
                 <legend className="usa-legend">Time Range</legend>
-                <div>
-                  <label className="usa-label">
-                    Start
-                    <input
-                      type="date"
-                      name="start"
-                      value={yearMonthDayFormat(start)}
-                      className="usa-input"
-                    />
-                  </label>
+                <div className="grid-row grid-gap">
+                  <div className="tablet:grid-col-6">
+                    <label className="usa-label">
+                      Start
+                      <input
+                        type="date"
+                        name="start"
+                        value={yearMonthDayFormat(start)}
+                        className="usa-input"
+                      />
+                    </label>
+                  </div>
+                  <div className="tablet:grid-col-6">
+                    <label className="usa-label">
+                      Finish
+                      <input
+                        type="date"
+                        name="finish"
+                        value={yearMonthDayFormat(finish)}
+                        className="usa-input"
+                      />
+                    </label>
+                  </div>
                 </div>
-                <div>
-                  <label className="usa-label">
-                    Finish
-                    <input
-                      type="date"
-                      name="finish"
-                      value={yearMonthDayFormat(finish)}
-                      className="usa-input"
-                    />
-                  </label>
-                </div>
-                <div className="margin-top-2">
-                  <button
-                    type="button"
-                    className="usa-button"
-                    onClick={updateTimeRange(utcWeek, -1)}
-                  >
-                    &larr; Previous Week
-                  </button>
-                  <button
-                    type="button"
-                    className="usa-button"
-                    onClick={updateTimeRange(utcWeek, +1)}
-                  >
-                    Next Week &rarr;
-                  </button>
+                <div className="margin-top-2 grid-row grid-gap">
+                  <div className="tablet:grid-col-6">
+                    <button
+                      type="button"
+                      className="usa-button usa-button--full-width margin-bottom-1"
+                      onClick={updateTimeRange(utcWeek, -1)}
+                    >
+                      &larr; Previous Week
+                    </button>
+                  </div>
+                  <div className="tablet:grid-col-6">
+                    <button
+                      type="button"
+                      className="usa-button usa-button--full-width"
+                      onClick={updateTimeRange(utcWeek, +1)}
+                    >
+                      Next Week &rarr;
+                    </button>
+                  </div>
                 </div>
               </fieldset>
               <fieldset className="usa-fieldset">


### PR DESCRIPTION
1. probably easier to see through screenshots:
2. probably easiest to view with [whitespace changes hidden (`?w=1`)](https://github.com/18F/identity-reporting/pull/38/files?w=1)

| size | before | after |
| --- | --- | --- |
| big |<img width="789" alt="Screen Shot 2021-09-30 at 3 01 53 PM" src="https://user-images.githubusercontent.com/458784/135536289-bf2055dd-4c63-4a63-9cd7-874a3be44ed7.png"> | <img width="789" alt="Screen Shot 2021-09-30 at 3 01 59 PM" src="https://user-images.githubusercontent.com/458784/135536304-e7f398b9-ca46-40cd-98c0-a389c84f121b.png"> |
| medium | <img width="524" alt="Screen Shot 2021-09-30 at 3 03 21 PM" src="https://user-images.githubusercontent.com/458784/135536309-5d690e28-0847-4bbb-8888-e458f9e7fe2b.png"> | <img width="524" alt="Screen Shot 2021-09-30 at 3 03 28 PM" src="https://user-images.githubusercontent.com/458784/135536316-fd06b1f2-b344-4b75-9fc2-70219051a431.png"> |
| small | <img width="292" alt="Screen Shot 2021-09-30 at 3 04 24 PM" src="https://user-images.githubusercontent.com/458784/135536333-411ac977-b3c3-49c3-bd64-2d6621ef76c8.png"> | <img width="292" alt="Screen Shot 2021-09-30 at 3 04 10 PM" src="https://user-images.githubusercontent.com/458784/135536338-c93b12d3-660b-4282-8180-fecb94ad8fc5.png"> |



 