### PR TITLE
Handle missing data in daily auths report

### DIFF
--- a/src/models/daily-auths-report-data.test.ts
+++ b/src/models/daily-auths-report-data.test.ts
@@ -31,10 +31,6 @@ describe("DailyAuthsReportData", () => {
       });
     });
 
-    after(() => fetchMock.restore());
-  });
-
-  describe("#loadData", () => {
     it("gracefully handles missing days", () => {
       const fetch = fetchMock
         .sandbox()

--- a/src/models/daily-auths-report-data.test.ts
+++ b/src/models/daily-auths-report-data.test.ts
@@ -33,4 +33,30 @@ describe("DailyAuthsReportData", () => {
 
     after(() => fetchMock.restore());
   });
+
+  describe("#loadData", () => {
+    it("gracefully handles missing days", () => {
+      const fetch = fetchMock
+        .sandbox()
+        .get("/local/daily-auths-report/2021/2021-01-01.daily-auths-report.json", {
+          start: "2020-01-01",
+          results: [{ count: 1 }],
+        })
+        .get("/local/daily-auths-report/2021/2021-01-02.daily-auths-report.json", 403);
+
+      return loadData(
+        yearMonthDayParse("2021-01-01"),
+        yearMonthDayParse("2021-01-03"),
+        "local",
+        fetch
+      ).then((processed) => {
+        expect(processed).to.have.lengthOf(1);
+        processed.forEach((result) => {
+          expect(result).to.have.property("date");
+        });
+      });
+    });
+
+    after(() => fetchMock.restore());
+  });
 });

--- a/src/models/daily-auths-report-data.ts
+++ b/src/models/daily-auths-report-data.ts
@@ -51,7 +51,9 @@ function loadData(
   return Promise.all(
     utcDays(start, finish, 1).map((date) => {
       const path = reportPath({ reportName: "daily-auths-report", date, env });
-      return fetch(path).then((response) => response.json());
+      return fetch(path).then((response) =>
+        response.status === 200 ? response.json() : { results: [] }
+      );
     })
   ).then((reports) => reports.flatMap((r) => process(r)));
 }

--- a/src/models/daily-dropoffs-report-data.test.ts
+++ b/src/models/daily-dropoffs-report-data.test.ts
@@ -127,6 +127,26 @@ issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+
       });
     });
 
+    it("gracefully handles missing days", () => {
+      const fetch = fetchMock
+        .sandbox()
+        .get(
+          "/local/daily-dropoffs-report/2021/2021-01-01.daily-dropoffs-report.csv",
+          `issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
+issuer1,The App,iaa123,The Agency,2021-01-01T00:00:00+01:00,2021-01-01T23:59:59+01:00,3,2,2,2,2,2,2,2,2,2,1`
+        )
+        .get("/local/daily-dropoffs-report/2021/2021-01-02.daily-dropoffs-report.csv", 403);
+
+      return loadData(
+        yearMonthDayParse("2021-01-01"),
+        yearMonthDayParse("2021-01-03"),
+        "local",
+        fetch
+      ).then((combinedRows) => {
+        expect(combinedRows).to.have.lengthOf(1);
+      });
+    });
+
     after(() => fetchMock.restore());
   });
 


### PR DESCRIPTION
- Add regression spec for dropoffs report

When we have some days back, act as if they're zero rather than blow up the whole page

| before | after |
| --- | ---- |
| <img width="992" alt="Screen Shot 2021-09-30 at 3 26 43 PM" src="https://user-images.githubusercontent.com/458784/135538326-6406602a-5fd7-4373-a9f6-f911a53286b4.png"> | <img width="992" alt="Screen Shot 2021-09-30 at 3 26 53 PM" src="https://user-images.githubusercontent.com/458784/135538343-1bc1772f-f29f-4f0f-9c65-f7cc3703c7e3.png"> |
 