### PR TITLE
Bring back all-agency view

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,29 +97,7 @@
       </section>
     </header>
     <main class="margin-0 padding-1">
-      <header class="usa-header usa-header--extended">
-        <div class="usa-navbar">
-          <div class="usa-logo">
-            <Link href="/" title="Home" aria-label="Home">
-              <img src="/node_modules/identity-style-guide/dist/assets/img/login-gov-logo.svg" class="usa-logo__img" alt="Login.gov" />
-              <em class="usa-logo__text">
-                Data
-                <span class="usa-tag bg-blue margin-left-05">Beta</span>
-              </em>
-            </Link>
-          </div>
-          <button class="usa-menu-btn" type="button">
-            Menu
-          </button>
-        </div>
-      </header>
-      <div class="grid-container">
-        <div class="grid-row">
-          <div class="grid-col-fill">
-            <h1>Coming Soon</h1>
-          </div>
-        </div>
-      </div>
+      <div id="app"></div>
     </main>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,9 @@
 import "./css/style.scss";
 
+import { render } from "preact";
 import { banner, accordion, navigation } from "identity-style-guide";
+import { Routes } from "./routes";
 
 [banner, accordion, navigation].forEach((component) => component.on());
+
+render(<Routes />, document.getElementById("app") as HTMLElement);


### PR DESCRIPTION
This reverts commit 06cf5f896750812c0c2c0e0ee76c9f39354f3542.

- Brings us back to aggregation across all agences (see screenshots in #45)

(Context: we had some wires crossed internally about what to show while we work on high-level data vs agency drilldown, got confirmation from @TiffanyAndrews this this OK to show)