### PR TITLE
include end date in range

### DIFF
--- a/src/models/daily-auths-report-data.test.ts
+++ b/src/models/daily-auths-report-data.test.ts
@@ -15,6 +15,10 @@ describe("DailyAuthsReportData", () => {
         .get("/local/daily-auths-report/2021/2021-01-02.daily-auths-report.json", {
           start: "2020-01-02",
           results: [{ count: 10 }],
+        })
+        .get("/local/daily-auths-report/2021/2021-01-03.daily-auths-report.json", {
+          start: "2020-01-03",
+          results: [{ count: 13 }],
         });
 
       return loadData(
@@ -23,7 +27,7 @@ describe("DailyAuthsReportData", () => {
         "local",
         fetch
       ).then((processed) => {
-        expect(processed).to.have.lengthOf(2);
+        expect(processed).to.have.lengthOf(3);
         processed.forEach((result) => {
           expect(result).to.have.property("date");
           expect(result.agency, "sets a default agency if missing").to.not.be.undefined;
@@ -38,7 +42,11 @@ describe("DailyAuthsReportData", () => {
           start: "2020-01-01",
           results: [{ count: 1 }],
         })
-        .get("/local/daily-auths-report/2021/2021-01-02.daily-auths-report.json", 403);
+        .get("/local/daily-auths-report/2021/2021-01-02.daily-auths-report.json", {
+          start: "2020-01-02",
+          results: [{ count: 2 }],
+        })
+        .get("/local/daily-auths-report/2021/2021-01-03.daily-auths-report.json", 403);
 
       return loadData(
         yearMonthDayParse("2021-01-01"),
@@ -46,7 +54,7 @@ describe("DailyAuthsReportData", () => {
         "local",
         fetch
       ).then((processed) => {
-        expect(processed).to.have.lengthOf(1);
+        expect(processed).to.have.lengthOf(2);
         processed.forEach((result) => {
           expect(result).to.have.property("date");
         });

--- a/src/models/daily-auths-report-data.ts
+++ b/src/models/daily-auths-report-data.ts
@@ -49,12 +49,14 @@ function loadData(
   fetch = window.fetch
 ): Promise<ProcessedResult[]> {
   return Promise.all(
-    utcDays(start, finish, 1).map((date) => {
-      const path = reportPath({ reportName: "daily-auths-report", date, env });
-      return fetch(path).then((response) =>
-        response.status === 200 ? response.json() : { results: [] }
-      );
-    })
+    utcDays(start, finish, 1)
+      .concat(finish)
+      .map((date) => {
+        const path = reportPath({ reportName: "daily-auths-report", date, env });
+        return fetch(path).then((response) =>
+          response.status === 200 ? response.json() : { results: [] }
+        );
+      })
   ).then((reports) => reports.flatMap((r) => process(r)));
 }
 

--- a/src/models/daily-dropoffs-report-data.test.ts
+++ b/src/models/daily-dropoffs-report-data.test.ts
@@ -176,6 +176,11 @@ issuer1,The App,iaa123,The Agency,2021-01-01T00:00:00+01:00,2021-01-01T23:59:59+
           "/local/daily-dropoffs-report/2021/2021-01-02.daily-dropoffs-report.csv",
           `issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
 issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+01:00,2,1,1,1,1,1,1,1,1,1,0`
+        )
+        .get(
+          "/local/daily-dropoffs-report/2021/2021-01-03.daily-dropoffs-report.csv",
+          `issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
+issuer1,The App,iaa123,The Agency,2021-01-03T00:00:00+01:00,2021-01-03T23:59:59+01:00,1,1,1,1,1,1,1,1,1,1,1`
         );
 
       return loadData(
@@ -188,8 +193,8 @@ issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+
         const row = combinedRows[0];
         expect(row.issuer).to.equal("issuer1");
         expect(row.friendly_name).to.equal("The App");
-        expect(row.welcome).to.equal(5);
-        expect(row.verified).to.equal(1);
+        expect(row.welcome).to.equal(6);
+        expect(row.verified).to.equal(2);
       });
     });
 
@@ -201,7 +206,12 @@ issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+
           `issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
 issuer1,The App,iaa123,The Agency,2021-01-01T00:00:00+01:00,2021-01-01T23:59:59+01:00,3,2,2,2,2,2,2,2,2,2,1`
         )
-        .get("/local/daily-dropoffs-report/2021/2021-01-02.daily-dropoffs-report.csv", 403);
+        .get(
+          "/local/daily-dropoffs-report/2021/2021-01-02.daily-dropoffs-report.csv",
+          `issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
+issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+01:00,3,2,2,2,2,2,2,2,2,2,1`
+        )
+        .get("/local/daily-dropoffs-report/2021/2021-01-03.daily-dropoffs-report.csv", 403);
 
       return loadData(
         yearMonthDayParse("2021-01-01"),
@@ -209,6 +219,8 @@ issuer1,The App,iaa123,The Agency,2021-01-01T00:00:00+01:00,2021-01-01T23:59:59+
         "local",
         fetch
       ).then((combinedRows) => {
+        const row = combinedRows[0];
+        expect(row.welcome).to.equal(6);
         expect(combinedRows).to.have.lengthOf(1);
       });
     });

--- a/src/models/daily-dropoffs-report-data.ts
+++ b/src/models/daily-dropoffs-report-data.ts
@@ -159,10 +159,17 @@ function loadData(
   fetch = window.fetch
 ): Promise<DailyDropoffsRow[]> {
   return Promise.all(
-    utcDays(start, finish, 1).map((date) => {
-      const path = reportPath({ reportName: "daily-dropoffs-report", date, env, extension: "csv" });
-      return fetch(path).then((response) => response.text());
-    })
+    utcDays(start, finish, 1)
+      .concat(finish)
+      .map((date) => {
+        const path = reportPath({
+          reportName: "daily-dropoffs-report",
+          date,
+          env,
+          extension: "csv",
+        });
+        return fetch(path).then((response) => response.text());
+      })
   ).then((reports) => aggregate(reports.flatMap((r) => process(r))));
 }
 


### PR DESCRIPTION
Currently, selecting the range "December 12th, 2021" - "December 13th, 2021" in the UI results in querying only December 12th because `utcDays(start, finish, 1)` returns a date range excluding the final date.

This patch updates the behavior to include the end date in the queries using the recommendation found in a d3-time issue [here](https://github.com/d3/d3-array/issues/90#issuecomment-642761443)