### PR TITLE
Fix last day not being included in report (LG-5513)

### DIFF
--- a/src/components/daily-auths-report.tsx
+++ b/src/components/daily-auths-report.tsx
@@ -38,7 +38,7 @@ function plot({
       tickFormat: formatSIDropTrailingZeroes,
     },
     x: {
-      domain: [start, finish],
+      domain: [start, utcDay.offset(finish, 1)],
     },
     facet: facetAgency
       ? {

--- a/src/models/daily-auths-report-data.test.ts
+++ b/src/models/daily-auths-report-data.test.ts
@@ -15,6 +15,10 @@ describe("DailyAuthsReportData", () => {
         .get("/local/daily-auths-report/2021/2021-01-02.daily-auths-report.json", {
           start: "2020-01-02",
           results: [{ count: 10 }],
+        })
+        .get("/local/daily-auths-report/2021/2021-01-03.daily-auths-report.json", {
+          start: "2020-01-03",
+          results: [{ count: 5 }],
         });
 
       return loadData(
@@ -23,7 +27,7 @@ describe("DailyAuthsReportData", () => {
         "local",
         fetch
       ).then((processed) => {
-        expect(processed).to.have.lengthOf(2);
+        expect(processed).to.have.lengthOf(3);
         processed.forEach((result) => {
           expect(result).to.have.property("date");
           expect(result.agency, "sets a default agency if missing").to.not.be.undefined;

--- a/src/models/daily-auths-report-data.test.ts
+++ b/src/models/daily-auths-report-data.test.ts
@@ -42,7 +42,8 @@ describe("DailyAuthsReportData", () => {
           start: "2020-01-01",
           results: [{ count: 1 }],
         })
-        .get("/local/daily-auths-report/2021/2021-01-02.daily-auths-report.json", 403);
+        .get("/local/daily-auths-report/2021/2021-01-02.daily-auths-report.json", 403)
+        .get("/local/daily-auths-report/2021/2021-01-03.daily-auths-report.json", 403);
 
       return loadData(
         yearMonthDayParse("2021-01-01"),

--- a/src/models/daily-auths-report-data.ts
+++ b/src/models/daily-auths-report-data.ts
@@ -1,4 +1,4 @@
-import { utcDays, timeDay } from "d3-time";
+import { utcDays, utcDay } from "d3-time";
 import { path as reportPath } from "./api-path";
 
 interface Result {
@@ -49,7 +49,7 @@ function loadData(
   fetch = window.fetch
 ): Promise<ProcessedResult[]> {
   return Promise.all(
-    utcDays(start, timeDay.ceil(finish), 1).map((date) => {
+    utcDays(start, utcDay.offset(finish, 1), 1).map((date) => {
       const path = reportPath({ reportName: "daily-auths-report", date, env });
       return fetch(path).then((response) =>
         response.status === 200 ? response.json() : { results: [] }

--- a/src/models/daily-auths-report-data.ts
+++ b/src/models/daily-auths-report-data.ts
@@ -1,4 +1,4 @@
-import { utcDays } from "d3-time";
+import { utcDays, timeDay } from "d3-time";
 import { path as reportPath } from "./api-path";
 
 interface Result {
@@ -48,10 +48,8 @@ function loadData(
   env: string,
   fetch = window.fetch
 ): Promise<ProcessedResult[]> {
-  // Set the "finish" to the ending of the day
-  finish.setUTCHours(23, 59, 59, 999);
   return Promise.all(
-    utcDays(start, finish, 1).map((date) => {
+    utcDays(start, timeDay.ceil(finish), 1).map((date) => {
       const path = reportPath({ reportName: "daily-auths-report", date, env });
       return fetch(path).then((response) =>
         response.status === 200 ? response.json() : { results: [] }

--- a/src/models/daily-auths-report-data.ts
+++ b/src/models/daily-auths-report-data.ts
@@ -48,6 +48,8 @@ function loadData(
   env: string,
   fetch = window.fetch
 ): Promise<ProcessedResult[]> {
+  // Set the "finish" to the ending of the day
+  finish.setUTCHours(23, 59, 59, 999);
   return Promise.all(
     utcDays(start, finish, 1).map((date) => {
       const path = reportPath({ reportName: "daily-auths-report", date, env });

--- a/src/models/daily-dropoffs-report-data.test.ts
+++ b/src/models/daily-dropoffs-report-data.test.ts
@@ -176,6 +176,11 @@ issuer1,The App,iaa123,The Agency,2021-01-01T00:00:00+01:00,2021-01-01T23:59:59+
           "/local/daily-dropoffs-report/2021/2021-01-02.daily-dropoffs-report.csv",
           `issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
 issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+01:00,2,1,1,1,1,1,1,1,1,1,0`
+        )
+        .get(
+          "/local/daily-dropoffs-report/2021/2021-01-03.daily-dropoffs-report.csv",
+          `issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
+issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+01:00,2,1,1,1,1,1,1,1,1,1,0`
         );
 
       return loadData(
@@ -188,7 +193,7 @@ issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+
         const row = combinedRows[0];
         expect(row.issuer).to.equal("issuer1");
         expect(row.friendly_name).to.equal("The App");
-        expect(row.welcome).to.equal(5);
+        expect(row.welcome).to.equal(7);
         expect(row.verified).to.equal(1);
       });
     });
@@ -201,7 +206,8 @@ issuer1,The App,iaa123,The Agency,2021-01-02T00:00:00+01:00,2021-01-02T23:59:59+
           `issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
 issuer1,The App,iaa123,The Agency,2021-01-01T00:00:00+01:00,2021-01-01T23:59:59+01:00,3,2,2,2,2,2,2,2,2,2,1`
         )
-        .get("/local/daily-dropoffs-report/2021/2021-01-02.daily-dropoffs-report.csv", 403);
+        .get("/local/daily-dropoffs-report/2021/2021-01-02.daily-dropoffs-report.csv", 403)
+        .get("/local/daily-dropoffs-report/2021/2021-01-03.daily-dropoffs-report.csv", 403);
 
       return loadData(
         yearMonthDayParse("2021-01-01"),

--- a/src/models/daily-dropoffs-report-data.ts
+++ b/src/models/daily-dropoffs-report-data.ts
@@ -158,6 +158,8 @@ function loadData(
   env: string,
   fetch = window.fetch
 ): Promise<DailyDropoffsRow[]> {
+  // Set the "finish" to the ending of the day
+  finish.setUTCHours(23, 59, 59, 999);
   return Promise.all(
     utcDays(start, finish, 1).map((date) => {
       const path = reportPath({ reportName: "daily-dropoffs-report", date, env, extension: "csv" });

--- a/src/models/daily-dropoffs-report-data.ts
+++ b/src/models/daily-dropoffs-report-data.ts
@@ -1,6 +1,6 @@
 import { group, ascending } from "d3-array";
 import { csvParse, autoType } from "d3-dsv";
-import { utcDays } from "d3-time";
+import { utcDays, timeDay } from "d3-time";
 import { path as reportPath } from "./api-path";
 import { FunnelMode } from "../contexts/report-filter-context";
 
@@ -158,10 +158,8 @@ function loadData(
   env: string,
   fetch = window.fetch
 ): Promise<DailyDropoffsRow[]> {
-  // Set the "finish" to the ending of the day
-  finish.setUTCHours(23, 59, 59, 999);
   return Promise.all(
-    utcDays(start, finish, 1).map((date) => {
+    utcDays(start, timeDay.ceil(finish), 1).map((date) => {
       const path = reportPath({ reportName: "daily-dropoffs-report", date, env, extension: "csv" });
       return fetch(path).then((response) => response.text());
     })

--- a/src/models/daily-dropoffs-report-data.ts
+++ b/src/models/daily-dropoffs-report-data.ts
@@ -1,6 +1,6 @@
 import { group, ascending } from "d3-array";
 import { csvParse, autoType } from "d3-dsv";
-import { utcDays, timeDay } from "d3-time";
+import { utcDays, utcDay } from "d3-time";
 import { path as reportPath } from "./api-path";
 import { FunnelMode } from "../contexts/report-filter-context";
 
@@ -159,7 +159,7 @@ function loadData(
   fetch = window.fetch
 ): Promise<DailyDropoffsRow[]> {
   return Promise.all(
-    utcDays(start, timeDay.ceil(finish), 1).map((date) => {
+    utcDays(start, utcDay.offset(finish, 1), 1).map((date) => {
       const path = reportPath({ reportName: "daily-dropoffs-report", date, env, extension: "csv" });
       return fetch(path).then((response) => response.text());
     })

--- a/src/routes/report-route.tsx
+++ b/src/routes/report-route.tsx
@@ -1,6 +1,6 @@
 import { VNode } from "preact";
 import { utcParse } from "d3-time-format";
-import { utcWeek } from "d3-time";
+import { utcWeek, utcDay } from "d3-time";
 import { AgenciesContextProvider } from "../contexts/agencies-context";
 import ReportFilterContextProvider, {
   DEFAULT_IAL,
@@ -46,7 +46,7 @@ function createReportRoute(
     funnelMode: funnelModeParam,
     scale: scaleParam,
   }: ReportRouteProps): VNode => {
-    const endOfPreviousWeek = utcWeek.floor(new Date());
+    const endOfPreviousWeek = utcDay.offset(utcWeek.floor(new Date()), -1);
     const startOfPreviousWeek = utcWeek.floor(new Date(endOfPreviousWeek.valueOf() - 1));
 
     const start = (startParam && yearMonthDayParse(startParam)) || startOfPreviousWeek;


### PR DESCRIPTION
Specs were also updated.

Core issue is that the "finish" date would be set to the beginning of the day, thus not include information that persists throughout the rest of the day.

Solution was to set the timestamp to the very end of the day - this ensures that we don't accidentally add a day to automated reports.

Originally something like 01/01/2020-01/03/2020 would only include 01/01/2020 @ 12:00AM - 01/03/2020 @ 12:00AM

This fix changes this behavior to report 01/01/2020 @ 12:00AM - 01/03/2020 @ 11:59PM as an example.

Specs had to be adjusted to recognize the change.