### PR TITLE
Separate issuer and friendly name in daily auths CSV

### DIFF
--- a/src/components/daily-auths-report.test.ts
+++ b/src/components/daily-auths-report.test.ts
@@ -52,11 +52,7 @@ describe("DailyAuthsReport", () => {
   describe("#tabulate", () => {
     function simplifyHeaderVNodes(header: TableRow): TableRow {
       const [agency, issuer, ...rest] = header;
-      return [
-        agency,
-        (issuer as VNode<any>).props.children,
-        ...rest
-      ]
+      return [agency, (issuer as VNode<any>).props.children, ...rest];
     }
     function simplifyBodyVNodes(body: TableRow[]): (string | number)[][] {
       return body.map(([agency, issuerSpan, ...rest]) => [

--- a/src/components/daily-auths-report.test.ts
+++ b/src/components/daily-auths-report.test.ts
@@ -50,7 +50,15 @@ describe("DailyAuthsReport", () => {
   ] as ProcessedResult[];
 
   describe("#tabulate", () => {
-    function simplifyVNodes(body: TableRow[]): (string | number)[][] {
+    function simplifyHeaderVNodes(header: TableRow): TableRow {
+      const [agency, issuer, ...rest] = header;
+      return [
+        agency,
+        (issuer as VNode<any>).props.children,
+        ...rest
+      ]
+    }
+    function simplifyBodyVNodes(body: TableRow[]): (string | number)[][] {
       return body.map(([agency, issuerSpan, ...rest]) => [
         agency,
         (issuerSpan as VNode<{ title: string }>).props.title,
@@ -61,7 +69,7 @@ describe("DailyAuthsReport", () => {
     it("builds a table by agency, issuer, ial", () => {
       const table = tabulate({ results });
 
-      expect(table.header).to.deep.eq([
+      expect(simplifyHeaderVNodes(table.header)).to.deep.eq([
         "Agency",
         "App",
         "Identity",
@@ -70,7 +78,7 @@ describe("DailyAuthsReport", () => {
         "Total",
       ]);
       expect(table.body).to.have.lengthOf(4);
-      expect(simplifyVNodes(table.body)).to.deep.equal([
+      expect(simplifyBodyVNodes(table.body)).to.deep.equal([
         ["agency1", "issuer1", "Authentication", 100, 111, 211],
         ["agency1", "issuer1", "Proofing", 1, 0, 1],
         ["agency1", "issuer2", "Authentication", 1000, 0, 1000],

--- a/src/components/daily-auths-report.tsx
+++ b/src/components/daily-auths-report.tsx
@@ -99,7 +99,13 @@ function tabulate({ results }: { results: ProcessedResult[] }): TableData {
     .sort((a, b) => a - b)
     .map((d) => new Date(d));
 
-  const header = ["Agency", "App", "Identity", ...days.map(yearMonthDayFormat), "Total"];
+  const header = [
+    "Agency",
+    <span data-csv={["Issuer", "Friendly Name"]}>App</span>,
+    "Identity",
+    ...days.map(yearMonthDayFormat),
+    "Total",
+  ];
 
   const grouped = group(
     results,
@@ -124,7 +130,11 @@ function tabulate({ results }: { results: ProcessedResult[] }): TableData {
 
             return [
               agency,
-              <td className="max-width-300 truncate-ellipsis" title={issuer}>
+              <td
+                className="max-width-300 truncate-ellipsis"
+                title={issuer}
+                data-csv={[issuer, issuerToFriendlyName.get(issuer)]}
+              >
                 {issuerToFriendlyName.get(issuer)} <small>({issuer})</small>
               </td>,
               ialLabel(ial),


### PR DESCRIPTION
This matches the style in the dropoffs report better, and is clearer data for actual processing

| before | after |
| --- | --- |
| <img width="818" alt="Screen Shot 2022-06-17 at 1 20 53 PM" src="https://user-images.githubusercontent.com/458784/174396173-94049e13-88dd-49f1-8f58-08d249a68e26.png"> | <img width="818" alt="Screen Shot 2022-06-17 at 1 20 45 PM" src="https://user-images.githubusercontent.com/458784/174396187-461c5ecc-9b24-4517-88ed-d76c0b2db88c.png"> |



 