### PR TITLE
Move aggregation behavior for "daily dropoffs" outside of "loadData"

### DIFF
--- a/src/components/daily-dropoffs-report.tsx
+++ b/src/components/daily-dropoffs-report.tsx
@@ -17,6 +17,7 @@ import {
   loadData,
   toStepCounts,
   aggregateAll,
+  aggregate,
 } from "../models/daily-dropoffs-report-data";
 import { formatAsPercent, formatWithCommas, yearMonthDayFormat } from "../formats";
 
@@ -124,7 +125,7 @@ function DailyDropffsReport(): VNode {
   useResizeListener(() => setWidth(ref.current?.offsetWidth));
   useAgencies(data);
 
-  const nonNullData = data || [];
+  const nonNullData = aggregate(data || []);
   const filteredData = (byAgency ? nonNullData : aggregateAll(nonNullData)).filter(
     (d) => !agency || d.agency === agency
   );

--- a/src/models/daily-dropoffs-report-data.ts
+++ b/src/models/daily-dropoffs-report-data.ts
@@ -163,7 +163,7 @@ function loadData(
       const path = reportPath({ reportName: "daily-dropoffs-report", date, env, extension: "csv" });
       return fetch(path).then((response) => response.text());
     })
-  ).then((reports) => aggregate(reports.flatMap((r) => process(r))));
+  ).then((reports) => reports.flatMap((r) => process(r)));
 }
 
 export {


### PR DESCRIPTION
**Why**: That way, loadData exposes more raw data, so we can process
it differently if needed

I was starting work on LG-6540, and this was causing a bunch of data
errors, because I was expecting de-aggregated data