### PR TITLE
Add table to proofing-over-time report (LG-6540)

### DIFF
--- a/src/components/proofing-over-time-report.test.ts
+++ b/src/components/proofing-over-time-report.test.ts
@@ -1,0 +1,86 @@
+import { expect } from "chai";
+import { scaleOrdinal } from "d3-scale";
+import { schemeCategory10 } from "d3-scale-chromatic";
+import { FunnelMode, TimeBucket } from "../contexts/report-filter-context";
+import { DailyDropoffsRow, Step } from "../models/daily-dropoffs-report-data";
+import { tabulateAll, tabulateByAgency, tabulateByIssuer } from "./proofing-over-time-report";
+
+describe("ProofingOverTimeReport", () => {
+  const date = new Date();
+  const rows = [
+    {
+      issuer: "issuer1",
+      friendly_name: "app1",
+      agency: "agency1",
+      start: date,
+      [Step.WELCOME]: 1,
+      [Step.AGREEMENT]: 0,
+      [Step.VERIFIED]: 1,
+    } as DailyDropoffsRow,
+    {
+      issuer: "issuer1",
+      friendly_name: "app1",
+      agency: "agency1",
+      start: date,
+      [Step.WELCOME]: 1,
+      [Step.AGREEMENT]: 1,
+      [Step.VERIFIED]: 1,
+    } as DailyDropoffsRow,
+    {
+      issuer: "issuer2",
+      friendly_name: "app2",
+      agency: "agency1",
+      start: date,
+      [Step.WELCOME]: 1,
+      [Step.AGREEMENT]: 0,
+      [Step.VERIFIED]: 0,
+    } as DailyDropoffsRow,
+    {
+      issuer: "issuer3",
+      friendly_name: "app3",
+      agency: "agency2",
+      start: date,
+      [Step.WELCOME]: 1,
+      [Step.AGREEMENT]: 0,
+      [Step.VERIFIED]: 0,
+    } as DailyDropoffsRow,
+  ];
+
+  describe("#tabulateAll", () => {
+    it("adds up across all agencies", () => {
+      const table = tabulateAll({
+        data: rows,
+        timeBucket: TimeBucket.WEEK,
+        funnelMode: FunnelMode.BLANKET,
+      });
+
+      expect(table.body).to.have.lengthOf(1);
+    });
+  });
+
+  describe("#tabulateByAgency", () => {
+    it("groups by agency", () => {
+      const table = tabulateByAgency({
+        data: rows,
+        timeBucket: TimeBucket.WEEK,
+        funnelMode: FunnelMode.BLANKET,
+        color: scaleOrdinal(schemeCategory10),
+      });
+
+      expect(table.body).to.have.lengthOf(2);
+    });
+  });
+
+  describe("#tabulateByIssuer", () => {
+    it("groups by issuer", () => {
+      const table = tabulateByIssuer({
+        data: rows,
+        timeBucket: TimeBucket.WEEK,
+        funnelMode: FunnelMode.BLANKET,
+        color: scaleOrdinal(schemeCategory10),
+      });
+
+      expect(table.body).to.have.lengthOf(3);
+    });
+  });
+});

--- a/src/components/proofing-over-time-report.tsx
+++ b/src/components/proofing-over-time-report.tsx
@@ -195,12 +195,7 @@ function tabulateByIssuer({
   const interval = timeBucket === TimeBucket.WEEK ? utcWeek : utcDay;
   const dates = bucketDates(data, interval);
 
-  const friendlyNameToIssuer = new Map<string, string>();
-  data.forEach((row) => {
-    if (!friendlyNameToIssuer.has(row.friendly_name)) {
-      friendlyNameToIssuer.set(row.friendly_name, row.issuer);
-    }
-  });
+  const friendlyNameToIssuer = new Map(data.map((row) => [row.friendly_name, row.issuer]));
 
   const totalByAgencyByIssuerByDate = rollup(
     data,

--- a/src/components/proofing-over-time-report.tsx
+++ b/src/components/proofing-over-time-report.tsx
@@ -3,8 +3,10 @@ import Markdown from "preact-markdown";
 import { useContext, useRef, useState } from "preact/hooks";
 import * as Plot from "@observablehq/plot";
 import { useQuery } from "preact-fetching";
-import { utcWeek, utcDay } from "d3-time";
-import { mean } from "d3-array";
+import { utcWeek, utcDay, CountableTimeInterval } from "d3-time";
+import { ascending, mean, rollup } from "d3-array";
+import { scaleOrdinal } from "d3-scale";
+import { schemeCategory10 } from "d3-scale-chromatic";
 import useResizeListener from "../hooks/resize-listener";
 import Accordion from "./accordion";
 import PlotComponent from "./plot";
@@ -16,13 +18,21 @@ import {
 } from "../contexts/report-filter-context";
 import {
   DailyDropoffsRow,
+  funnelSteps,
   loadData,
   Step,
   StepCount,
   toStepCounts,
 } from "../models/daily-dropoffs-report-data";
-import { formatAsPercent, formatSIDropTrailingZeroes } from "../formats";
+import {
+  formatAsPercent,
+  formatSIDropTrailingZeroes,
+  formatWithCommas,
+  yearMonthDayFormat,
+} from "../formats";
 import { useAgencies } from "../contexts/agencies-context";
+import Table, { TableData } from "./table";
+import { kebabCase } from "../strings";
 
 interface StepCountEntry extends StepCount {
   date: Date;
@@ -53,20 +63,208 @@ function flatten({
   return results;
 }
 
+function bucketDates(data: DailyDropoffsRow[], interval: CountableTimeInterval): Date[] {
+  return Array.from(new Set(data.map((row) => +interval.floor(row.start))))
+    .map((ms) => new Date(ms))
+    .sort((a, b) => ascending(a, b));
+}
+
+interface VerifiedTotal {
+  verified: number;
+  total: number;
+}
+
+const VERIFIED_TOTAL_ZERO: VerifiedTotal = { verified: 0, total: 0 };
+
+function sumToTotalVerified(bin: DailyDropoffsRow[], funnelMode: FunnelMode): VerifiedTotal {
+  const firstStep = funnelSteps(funnelMode)[0].key;
+
+  return bin.reduce(
+    ({ total, verified }, d) => ({ total: total + d[firstStep], verified: verified + d.verified }),
+    VERIFIED_TOTAL_ZERO
+  );
+}
+
+function sumOfTotalVerified(values: Map<any, VerifiedTotal>): VerifiedTotal {
+  return Array.from(values).reduce(
+    ({ total, verified }, [, d]) => ({ total: d.total + total, verified: d.verified + verified }),
+    VERIFIED_TOTAL_ZERO
+  );
+}
+
+function countAndPercent({ total, verified }: VerifiedTotal): [VNode, VNode] {
+  const fraction = verified / total || 0;
+
+  return [
+    <span data-csv={total}>{formatWithCommas(total)}</span>,
+    <span data-csv={fraction}>{formatAsPercent(fraction)}</span>,
+  ];
+}
+
+function tabulateAll({
+  data,
+  timeBucket,
+  funnelMode,
+}: {
+  data: DailyDropoffsRow[];
+  timeBucket: TimeBucket;
+  funnelMode: FunnelMode;
+}): TableData {
+  const interval = timeBucket === TimeBucket.WEEK ? utcWeek : utcDay;
+  const dates = bucketDates(data, interval);
+
+  const totalByDate = rollup(
+    data,
+    (bin) => sumToTotalVerified(bin, funnelMode),
+    (d) => +interval.floor(d.start)
+  );
+
+  const body = [
+    [
+      "(All)",
+      ...dates.flatMap((date) => countAndPercent(totalByDate.get(+date) || VERIFIED_TOTAL_ZERO)),
+      ...countAndPercent(sumOfTotalVerified(totalByDate)),
+    ],
+  ];
+
+  return {
+    header: [
+      "Agency",
+      ...dates.map((date) => <th colSpan={2}>{yearMonthDayFormat(date)}</th>),
+      <th colSpan={2}>Total</th>,
+    ],
+    body,
+  };
+}
+
+function tabulateByAgency({
+  data,
+  timeBucket,
+  funnelMode,
+  color,
+}: {
+  data: DailyDropoffsRow[];
+  timeBucket: TimeBucket;
+  funnelMode: FunnelMode;
+  color: (issuer: string) => string;
+}): TableData {
+  const interval = timeBucket === TimeBucket.WEEK ? utcWeek : utcDay;
+  const dates = bucketDates(data, interval);
+
+  const totalByAgencyByDate = rollup(
+    data,
+    (bin) => sumToTotalVerified(bin, funnelMode),
+    (d) => d.agency,
+    (d) => +interval.floor(d.start)
+  );
+
+  const header = [
+    "Agency",
+    ...dates.map((date) => <th colSpan={2}>{yearMonthDayFormat(date)}</th>),
+    <th colSpan={2}>Total</th>,
+  ];
+
+  const body = Array.from(totalByAgencyByDate)
+    .sort(([agencyA], [agencyB]) => ascending(agencyA, agencyB))
+    .map(([agency, totalByDate]) => [
+      <span data-csv={agency}>
+        <span style={`color: ${color(agency)}`}>⬤ </span>
+        {agency}
+      </span>,
+      ...dates.flatMap((date) => countAndPercent(totalByDate.get(+date) || VERIFIED_TOTAL_ZERO)),
+      ...countAndPercent(sumOfTotalVerified(totalByDate)),
+    ]);
+
+  return {
+    header,
+    body,
+  };
+}
+
+function tabulateByIssuer({
+  data,
+  timeBucket,
+  funnelMode,
+  color,
+}: {
+  data: DailyDropoffsRow[];
+  timeBucket: TimeBucket;
+  funnelMode: FunnelMode;
+  color: (issuer: string) => string;
+}): TableData {
+  const interval = timeBucket === TimeBucket.WEEK ? utcWeek : utcDay;
+  const dates = bucketDates(data, interval);
+
+  const friendlyNameToIssuer = new Map<string, string>();
+  data.forEach((row) => {
+    if (!friendlyNameToIssuer.has(row.friendly_name)) {
+      friendlyNameToIssuer.set(row.friendly_name, row.issuer);
+    }
+  });
+
+  const totalByAgencyByIssuerByDate = rollup(
+    data,
+    (bin) => sumToTotalVerified(bin, funnelMode),
+    (d) => d.agency,
+    (d) => d.friendly_name,
+    (d) => +interval.floor(d.start)
+  );
+
+  const header = [
+    "Agency",
+    <span data-csv={["Issuer", "Friendly Name"]}>App</span>,
+    ...dates.map((date) => <th colSpan={2}>{yearMonthDayFormat(date)}</th>),
+    <th colSpan={2}>Total</th>,
+  ];
+
+  const body = Array.from(totalByAgencyByIssuerByDate)
+    .sort(([agencyA], [agencyB]) => ascending(agencyA, agencyB))
+    .flatMap(([agency, issuers]) =>
+      Array.from(issuers)
+        .sort(([friendlyNameA], [friendlyNameB]) => ascending(friendlyNameA, friendlyNameB))
+        .map(([friendlyName, totalByDate]) => {
+          const issuer = friendlyNameToIssuer.get(friendlyName);
+
+          return [
+            agency,
+            <span title={issuer} data-csv={[issuer, friendlyName]}>
+              <span style={`color: ${color(friendlyName)}`}>⬤ </span>
+              {friendlyName}
+            </span>,
+            ...dates.flatMap((date) =>
+              countAndPercent(totalByDate.get(+date) || VERIFIED_TOTAL_ZERO)
+            ),
+            ...countAndPercent(sumOfTotalVerified(totalByDate)),
+          ];
+        })
+    );
+
+  return {
+    header,
+    body,
+  };
+}
+
 export default function ProofingOverTimeReport(): VNode {
   const ref = useRef(null as HTMLDivElement | null);
   const [width, setWidth] = useState(undefined as number | undefined);
-  const { start, finish, agency, env, funnelMode, scale, byAgency, timeBucket } =
-    useContext(ReportFilterContext);
+  const {
+    start,
+    finish,
+    agency,
+    env,
+    funnelMode,
+    scale,
+    byAgency,
+    timeBucket = TimeBucket.WEEK,
+  } = useContext(ReportFilterContext);
 
-  const { data } = useQuery(`${start.valueOf()}-${finish.valueOf()}`, () =>
+  const { data } = useQuery(`proofing-over-time-${start.valueOf()}-${finish.valueOf()}`, () =>
     loadData(start, finish, env)
   );
 
   useResizeListener(() => setWidth(ref.current?.offsetWidth));
   useAgencies(data);
-
-  const flatSteps = flatten({ data: data || [], funnelMode });
 
   const lineDeterminer = (() => {
     if (byAgency) {
@@ -76,14 +274,18 @@ export default function ProofingOverTimeReport(): VNode {
       return "agency";
     }
   })();
+  const color = scaleOrdinal(schemeCategory10);
+  const stroke = lineDeterminer ? (d: StepCountEntry) => color(d[lineDeterminer]) : undefined;
 
-  const filter = (d: StepCountEntry) =>
-    d.step === Step.VERIFIED && (!agency || d.agency === agency);
+  const filter = (d: StepCountEntry) => d.step === Step.VERIFIED;
   const thresholds = timeBucket === TimeBucket.DAY ? utcDay : utcWeek;
   const y = scale === Scale.PERCENT ? "percentOfFirst" : "count";
   const tickFormat = scale === Scale.PERCENT ? formatAsPercent : formatSIDropTrailingZeroes;
-
   const showAverages = (!byAgency || agency) && scale === Scale.PERCENT;
+
+  const filteredData = (data || []).filter((row) => !agency || row.agency === agency);
+
+  const flatSteps = flatten({ data: filteredData, funnelMode });
 
   return (
     <div ref={ref}>
@@ -127,7 +329,7 @@ The data model table can't accurately capture:
                     y,
                     thresholds,
                     z: lineDeterminer,
-                    stroke: lineDeterminer,
+                    stroke,
                     title: lineDeterminer,
                     filter,
                   }
@@ -140,7 +342,7 @@ The data model table can't accurately capture:
                     { y: "mean" },
                     {
                       z: lineDeterminer,
-                      stroke: lineDeterminer,
+                      stroke,
                       strokeDasharray: "3,2",
                       thresholds,
                       y,
@@ -162,7 +364,7 @@ The data model table can't accurately capture:
                           : finish,
                       dx: timeBucket === TimeBucket.DAY ? 15 : undefined,
                       z: lineDeterminer,
-                      fill: lineDeterminer,
+                      fill: stroke,
                       thresholds,
                       textAnchor: "start",
                       filter,
@@ -183,6 +385,36 @@ The data model table can't accurately capture:
           timeBucket,
         ]}
       />
+      {!byAgency && (
+        <Table
+          data={tabulateAll({
+            data: filteredData,
+            timeBucket,
+            funnelMode,
+          })}
+          filename={`proofing-over-time-report-${yearMonthDayFormat(start)}-to-${yearMonthDayFormat(
+            finish
+          )}.csv`}
+        />
+      )}
+      {byAgency && !agency && (
+        <Table
+          data={tabulateByAgency({ data: filteredData, timeBucket, funnelMode, color })}
+          filename={`proofing-over-time-report-agencies-${yearMonthDayFormat(start)}-to-${yearMonthDayFormat(
+            finish
+          )}.csv`}
+        />
+      )}
+      {byAgency && agency && (
+        <Table
+          data={tabulateByIssuer({ data: filteredData, timeBucket, funnelMode, color })}
+          filename={`proofing-over-time-report-${kebabCase(agency)}-${yearMonthDayFormat(start)}-to-${yearMonthDayFormat(
+            finish
+          )}.csv`}
+        />
+      )}
     </div>
   );
 }
+
+export { tabulateAll, tabulateByAgency, tabulateByIssuer };

--- a/src/contexts/report-filter-context.tsx
+++ b/src/contexts/report-filter-context.tsx
@@ -38,7 +38,7 @@ interface ReportFilterContextValues {
   scale: Scale;
   byAgency: boolean;
   extra: boolean;
-  timeBucket?: string
+  timeBucket?: TimeBucket
   setParameters: (params: Record<string, string>) => void;
 }
 


### PR DESCRIPTION
Adds the tables we know and love, with downloadability

It's the end of the day and I went a little light on the test coverage side... but if folks feel strongly, I can spend some more time adding more tests

**Note**: In some cases, the average (trendline) calculated by Plot does not match the one I calculate... 😬 

| screenshot |
| --- |
| <img width="1016" alt="Screen Shot 2022-06-28 at 4 54 44 PM" src="https://user-images.githubusercontent.com/458784/176323366-f6acff48-6b1b-4423-825b-dbfc70684775.png"> |

 