### PR TITLE
Update proofing-over-time table to show verified count

### DIFF
--- a/src/components/proofing-over-time-report.tsx
+++ b/src/components/proofing-over-time-report.tsx
@@ -96,7 +96,7 @@ function countAndPercent({ total, verified }: VerifiedTotal): [VNode, VNode] {
   const fraction = verified / total || 0;
 
   return [
-    <span data-csv={total}>{formatWithCommas(total)}</span>,
+    <span data-csv={verified}>{formatWithCommas(verified)}</span>,
     <span data-csv={fraction}>{formatAsPercent(fraction)}</span>,
   ];
 }


### PR DESCRIPTION
**Why**: We care about the number of successes more than
the number of attempts

Highlighted by @porta-antiporta, thanks!