### PR TITLE
Migrate Federalist to Cloud.gov Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postbuild": "npm run generate-routes && cp robots.txt _site/",
     "dev": "vite",
     "generate-routes": "node -r esbuild-register bin/generate-routes.js",
-    "federalist": "npm run build -- --base=${BASEURL:-/}",
+    "pages": "npm run build -- --base=${BASEURL:-/}",
     "prettier:fix": "npm run test:lint -- --fix",
     "serve": "vite preview",
     "test:lint": "eslint . --ext .js,.ts,.tsx",


### PR DESCRIPTION
**Why**: [Federalist is becoming Cloud.gov Pages](https://cloud.gov/pages/federalist-migration/), and as such we'll need to update configurations accordingly.

The webhook settings have already been updated, so these changes are updating the remaining code reference to Federalist.

Resources:

- [Slack confirmation of renamed script](https://gsa-tts.slack.com/archives/C1NUUGTT5/p1664896538701049)
- [Related code](https://github.com/cloud-gov/pages-build-container/blob/508bd8f/src/steps/build.py#L186-L200)