### PR TITLE
Create ALL_ROUTES constant, define all routes in one place

### DIFF
--- a/bin/generate-routes.js
+++ b/bin/generate-routes.js
@@ -1,8 +1,12 @@
 import { mkdir, copyFile } from "fs/promises";
 import { join } from "path";
 
+import ALL_ROUTES from "../src/routes/all";
+
+const reportRoutes = Object.keys(ALL_ROUTES).filter((route) => route !== "/");
+
 Promise.all(
-  ["/daily-auths-report/", "/daily-dropoffs-report/", "/proofing-over-time/"].map(async (path) => {
+  reportRoutes.map(async (path) => {
     const dir = join("_site", path);
     await mkdir(dir, { recursive: true });
     await copyFile("_site/index.html", join(dir, "index.html"));

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -5,6 +5,8 @@ import logoURL from "../../node_modules/identity-style-guide/dist/assets/img/log
 // eslint-disable-next-line import/no-relative-packages
 import closeURL from "../../node_modules/identity-style-guide/dist/assets/img/close.svg";
 
+import ALL_ROUTES from "../routes/all";
+
 interface HeaderProps {
   path: string;
 }
@@ -32,39 +34,16 @@ function Header({ path }: HeaderProps): VNode {
             <img src={closeURL} alt="Close" />
           </button>
           <ul className="usa-nav__primary usa-accordion">
-            <li className="usa-nav__primary-item">
-              <Link href="/" className={path === getFullPath("/") ? "usa-current" : undefined}>
-                Home
-              </Link>
-            </li>
-            <li className="usa-nav__primary-item">
-              <Link
-                href="/daily-auths-report/"
-                className={path === getFullPath("/daily-auths-report/") ? "usa-current" : undefined}
-              >
-                Daily Auths Report
-              </Link>
-            </li>
-            <li className="usa-nav__primary-item">
-              <Link
-                href="/daily-dropoffs-report/"
-                className={
-                  path === getFullPath("/daily-dropoffs-report/") ? "usa-current" : undefined
-                }
-              >
-                Daily Dropoffs Report
-              </Link>
-            </li>
-            <li className="usa-nav__primary-item">
-              <Link
-                href="/proofing-over-time/"
-                className={
-                  path === getFullPath("/proofing-over-time/") ? "usa-current" : undefined
-                }
-              >
-                Proofing Over Time Report
-              </Link>
-            </li>
+            {Object.entries(ALL_ROUTES).map(([routePath, title]) => (
+              <li className="usa-nav__primary-item">
+                <Link
+                  href={routePath}
+                  className={path === getFullPath(routePath) ? "usa-current" : undefined}
+                >
+                  {title}
+                </Link>
+              </li>
+            ))}
           </ul>
         </div>
       </nav>

--- a/src/routes/all.ts
+++ b/src/routes/all.ts
@@ -1,0 +1,11 @@
+/**
+ * POJO map of path <-> title, must be importable by node
+ */
+const ALL_ROUTES = {
+  "/": "Home",
+  "/daily-auths-report/": "Daily Auths Report",
+  "/daily-dropoffs-report/": "Daily Dropoffs Report",
+  "/proofing-over-time/": "Proofing Over Time Report",
+};
+
+export default ALL_ROUTES;

--- a/src/routes/all.ts
+++ b/src/routes/all.ts
@@ -1,5 +1,6 @@
 /**
  * POJO map of path <-> title, must be importable by node
+ * This is the one true list of all routes in this app
  */
 const ALL_ROUTES = {
   "/": "Home",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -33,7 +33,7 @@ export function Routes(): VNode {
   return (
     <Router>
       {Object.entries(reportRoutes).map(([path, Component]) => (
-        <Component path={path} />
+        <Component path={path as keyof ReportRoutes} />
       ))}
     </Router>
   );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,10 +5,15 @@ import DailyDropffsReport from "../components/daily-dropoffs-report";
 import ProofingOverTimeReport from "../components/proofing-over-time-report";
 import { Router } from "../router";
 import HomeRoute from "./home-route";
-import createReportRoute from "./report-route";
+import createReportRoute, { ReportRoute } from "./report-route";
 import { Scale } from "../contexts/report-filter-context";
+import ALL_ROUTES from "./all";
 
-export const ROUTES = {
+type ReportRoutes = {
+  [Property in keyof typeof ALL_ROUTES]: ReportRoute;
+}
+
+const reportRoutes: ReportRoutes = {
   "/daily-auths-report/": createReportRoute(DailyAuthsReport, {
     title: "Daily Auths Report",
     controls: [Control.IAL],
@@ -29,7 +34,7 @@ export const ROUTES = {
 export function Routes(): VNode {
   return (
     <Router>
-      {Object.entries(ROUTES).map(([path, Component]) => (
+      {Object.entries(reportRoutes).map(([path, Component]) => (
         <Component path={path} />
       ))}
     </Router>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,9 +12,7 @@ import ALL_ROUTES from "./all";
 /**
  * Requires that all keys in ALL_ROUTES have a matching key in this object
  */
-type ReportRoutes = {
-  [Property in keyof typeof ALL_ROUTES]: ReportRoute;
-}
+type ReportRoutes = Record<keyof typeof ALL_ROUTES, ReportRoute>;
 
 const reportRoutes: ReportRoutes = {
   "/daily-auths-report/": createReportRoute(DailyAuthsReport, {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,6 +9,9 @@ import createReportRoute, { ReportRoute } from "./report-route";
 import { Scale } from "../contexts/report-filter-context";
 import ALL_ROUTES from "./all";
 
+/**
+ * Requires that all keys in ALL_ROUTES have a matching key in this object
+ */
 type ReportRoutes = {
   [Property in keyof typeof ALL_ROUTES]: ReportRoute;
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -18,15 +18,12 @@ type ReportRoutes = {
 
 const reportRoutes: ReportRoutes = {
   "/daily-auths-report/": createReportRoute(DailyAuthsReport, {
-    title: "Daily Auths Report",
     controls: [Control.IAL],
   }),
   "/daily-dropoffs-report/": createReportRoute(DailyDropffsReport, {
-    title: "Daily Dropoffs Report",
     controls: [Control.FUNNEL_MODE, Control.SCALE],
   }),
   "/proofing-over-time/": createReportRoute(ProofingOverTimeReport, {
-    title: "Proofing Over Time Report",
     controls: [Control.FUNNEL_MODE, Control.SCALE, Control.TIME_BUCKET],
     defaultTimeRangeWeekOffset: -3,
     defaultScale: Scale.PERCENT,

--- a/src/routes/report-route.tsx
+++ b/src/routes/report-route.tsx
@@ -16,7 +16,9 @@ import Page from "../components/page";
 
 const yearMonthDayParse = utcParse("%Y-%m-%d");
 
-export interface ReportRouteProps {
+export type ReportRoute = (props: ReportRouteProps) => VNode;
+
+interface ReportRouteProps {
   path: string;
   start?: string;
   finish?: string;
@@ -56,7 +58,7 @@ function createReportRoute(
     defaultTimeRangeWeekOffset?: number;
     defaultScale?: Scale;
   }
-): (props: ReportRouteProps) => VNode {
+): ReportRoute {
   return ({
     path,
     start: startParam,

--- a/src/routes/report-route.tsx
+++ b/src/routes/report-route.tsx
@@ -13,6 +13,7 @@ import ReportFilterContextProvider, {
 } from "../contexts/report-filter-context";
 import ReportFilterControls, { Control } from "../components/report-filter-controls";
 import Page from "../components/page";
+import ALL_ROUTES from "./all";
 
 const yearMonthDayParse = utcParse("%Y-%m-%d");
 
@@ -48,12 +49,10 @@ interface ReportRouteProps {
 function createReportRoute(
   Report: () => VNode,
   {
-    title,
     controls,
     defaultScale,
     defaultTimeRangeWeekOffset = 0,
   }: {
-    title: string;
     controls?: Control[];
     defaultTimeRangeWeekOffset?: number;
     defaultScale?: Scale;
@@ -92,6 +91,8 @@ function createReportRoute(
       reportControls.push(Control.AGENCY);
       reportControls.push(Control.BY_AGENCY);
     }
+
+    const title = (ALL_ROUTES as Record<string, string>)[path];
 
     return (
       <Page path={path} title={title}>

--- a/src/routes/report-route.tsx
+++ b/src/routes/report-route.tsx
@@ -20,7 +20,7 @@ const yearMonthDayParse = utcParse("%Y-%m-%d");
 export type ReportRoute = (props: ReportRouteProps) => VNode;
 
 interface ReportRouteProps {
-  path: string;
+  path: keyof typeof ALL_ROUTES;
   start?: string;
   finish?: string;
   ial?: string;
@@ -92,7 +92,7 @@ function createReportRoute(
       reportControls.push(Control.BY_AGENCY);
     }
 
-    const title = (ALL_ROUTES as Record<string, string>)[path];
+    const title = ALL_ROUTES[path];
 
     return (
       <Page path={path} title={title}>


### PR DESCRIPTION
Used by:
- generate-routes (static node script)
- header.tsx (for the nav)
- index.tsx (to map to actual report compontent)

This is round 2 of https://github.com/18F/identity-reporting/pull/74, I opted to create a second file and use TS to require full usage, instead of trying to get cute and only have one file