### PR TITLE
Show deletes on Daily Registrations Report

### DIFF
--- a/src/components/daily-registrations-report.test.tsx
+++ b/src/components/daily-registrations-report.test.tsx
@@ -37,7 +37,7 @@ describe("DailyRegistrationsReport", () => {
           ["Deleted Users", 3, 4],
           ["Cumulative Users", 10, 17],
           ["Cumulative Fully Registered Users", 2, 4],
-          ["Deleted Users Cumulative", 5, 9],
+          ["Cumulative Deleted Users", 5, 9],
         ],
       });
     });

--- a/src/components/daily-registrations-report.test.tsx
+++ b/src/components/daily-registrations-report.test.tsx
@@ -13,6 +13,8 @@ describe("DailyRegistrationsReport", () => {
           fullyRegisteredUsers: 1,
           totalUsersCumulative: 10,
           fullyRegisteredUsersCumulative: 2,
+          deletedUsers: 3,
+          deletedUsersCumulative: 5,
         },
         {
           date: yearMonthDayParse("2020-01-02"),
@@ -20,6 +22,8 @@ describe("DailyRegistrationsReport", () => {
           fullyRegisteredUsers: 2,
           totalUsersCumulative: 17,
           fullyRegisteredUsersCumulative: 4,
+          deletedUsers: 4,
+          deletedUsersCumulative: 9,
         },
       ];
 
@@ -30,8 +34,10 @@ describe("DailyRegistrationsReport", () => {
         body: [
           ["New Users", 5, 6],
           ["New Fully Registered Users", 1, 2],
+          ["Deleted Users", 3, 4],
           ["Cumulative Users", 10, 17],
           ["Cumulative Fully Registered Users", 2, 4],
+          ["Deleted Users Cumulative", 5, 9],
         ],
       });
     });

--- a/src/components/daily-registrations-report.tsx
+++ b/src/components/daily-registrations-report.tsx
@@ -30,7 +30,7 @@ function plot({ data, width }: { data: ProcessedRenderableData[]; width?: number
             return "Total Users";
           case DataType.FULLY_REGISTERED_USERS:
           case DataType.FULLY_REGISTERED_USERS_CUMULATIVE:
-            return "Full Registered Users";
+            return "Fully Registered Users";
           case DataType.DELETED_USERS:
           case DataType.DELETED_USERS_CUMULATIVE:
             return "Deleted Users";

--- a/src/components/daily-registrations-report.tsx
+++ b/src/components/daily-registrations-report.tsx
@@ -22,6 +22,7 @@ function plot({ data, width }: { data: ProcessedRenderableData[]; width?: number
     color: {
       legend: true,
       type: "ordinal",
+      scheme: "category10",
       tickFormat: (type: DataType): string => {
         switch (type) {
           case DataType.TOTAL_USERS:
@@ -30,6 +31,9 @@ function plot({ data, width }: { data: ProcessedRenderableData[]; width?: number
           case DataType.FULLY_REGISTERED_USERS:
           case DataType.FULLY_REGISTERED_USERS_CUMULATIVE:
             return "Full Registered Users";
+          case DataType.DELETED_USERS:
+          case DataType.DELETED_USERS_CUMULATIVE:
+            return "Deleted Users";
           default:
             throw new Error(`Unknown type ${type}`);
         }
@@ -68,6 +72,11 @@ function tabulate(results: ProcessedResult[]): TableData {
         "Cumulative Fully Registered Users",
         ...results.map(({ fullyRegisteredUsersCumulative }) => fullyRegisteredUsersCumulative),
       ],
+      ["Deleted Users", ...results.map(({ deletedUsers }) => deletedUsers)],
+      [
+        "Cumulative Deleted Users",
+        ...results.map(({ deletedUsersCumulative }) => deletedUsersCumulative),
+      ],
     ],
   };
 }
@@ -86,9 +95,11 @@ function DailyRegistrationsReport(): VNode {
       switch (type) {
         case DataType.TOTAL_USERS:
         case DataType.FULLY_REGISTERED_USERS:
+        case DataType.DELETED_USERS:
           return !cumulative;
         case DataType.TOTAL_USERS_CUMULATIVE:
         case DataType.FULLY_REGISTERED_USERS_CUMULATIVE:
+        case DataType.DELETED_USERS_CUMULATIVE:
           return !!cumulative;
         default:
           throw new Error(`Unknown data type ${type}`);

--- a/src/components/daily-registrations-report.tsx
+++ b/src/components/daily-registrations-report.tsx
@@ -22,7 +22,7 @@ function plot({ data, width }: { data: ProcessedRenderableData[]; width?: number
     color: {
       legend: true,
       type: "ordinal",
-      scheme: "category10",
+      scheme: "Tableau10",
       tickFormat: (type: DataType): string => {
         switch (type) {
           case DataType.TOTAL_USERS:

--- a/src/components/daily-registrations-report.tsx
+++ b/src/components/daily-registrations-report.tsx
@@ -67,12 +67,12 @@ function tabulate(results: ProcessedResult[]): TableData {
         "New Fully Registered Users",
         ...results.map(({ fullyRegisteredUsers }) => fullyRegisteredUsers),
       ],
+      ["Deleted Users", ...results.map(({ deletedUsers }) => deletedUsers)],
       ["Cumulative Users", ...results.map(({ totalUsersCumulative }) => totalUsersCumulative)],
       [
         "Cumulative Fully Registered Users",
         ...results.map(({ fullyRegisteredUsersCumulative }) => fullyRegisteredUsersCumulative),
       ],
-      ["Deleted Users", ...results.map(({ deletedUsers }) => deletedUsers)],
       [
         "Cumulative Deleted Users",
         ...results.map(({ deletedUsersCumulative }) => deletedUsersCumulative),

--- a/src/models/daily-registrations-report-data.test.ts
+++ b/src/models/daily-registrations-report-data.test.ts
@@ -11,8 +11,8 @@ describe("DailyRegistrationsReportData", () => {
         .get("/local/daily-registrations-report/2021/2021-01-02.daily-registrations-report.json", {
           finish: "2020-01-03",
           results: [
-            { date: "2020-01-01", total_users: 2, fully_registered_users: 1 },
-            { date: "2020-01-02", total_users: 20, fully_registered_users: 10 },
+            { date: "2020-01-01", total_users: 2, fully_registered_users: 1, deleted_users: 1 },
+            { date: "2020-01-02", total_users: 20, fully_registered_users: 10, deleted_users: 1 },
           ],
         });
 
@@ -26,6 +26,8 @@ describe("DailyRegistrationsReportData", () => {
               fullyRegisteredUsers: 1,
               totalUsersCumulative: 2,
               fullyRegisteredUsersCumulative: 1,
+              deletedUsers: 1,
+              deletedUsersCumulative: 1,
             },
             {
               date: yearMonthDayParse("2020-01-02"),
@@ -33,6 +35,8 @@ describe("DailyRegistrationsReportData", () => {
               fullyRegisteredUsers: 10,
               totalUsersCumulative: 22,
               fullyRegisteredUsersCumulative: 11,
+              deletedUsers: 1,
+              deletedUsersCumulative: 2,
             },
           ]);
         }
@@ -49,6 +53,8 @@ describe("DailyRegistrationsReportData", () => {
           fullyRegisteredUsers: 2,
           totalUsersCumulative: 3,
           fullyRegisteredUsersCumulative: 4,
+          deletedUsers: 5,
+          deletedUsersCumulative: 6,
         },
       ]);
 
@@ -72,6 +78,16 @@ describe("DailyRegistrationsReportData", () => {
           date: yearMonthDayParse("2020-01-01"),
           type: DataType.FULLY_REGISTERED_USERS_CUMULATIVE,
           value: 4,
+        },
+        {
+          date: yearMonthDayParse("2020-01-01"),
+          type: DataType.DELETED_USERS,
+          value: 5,
+        },
+        {
+          date: yearMonthDayParse("2020-01-01"),
+          type: DataType.DELETED_USERS_CUMULATIVE,
+          value: 6,
         },
       ]);
     });


### PR DESCRIPTION
These screenshots are from `int`, the prod data will be available next week.

| description | screenshot |
|----|-----|
| graph | <img width="917" alt="Screen Shot 2023-02-03 at 2 51 18 PM" src="https://user-images.githubusercontent.com/458784/216725921-c314dfe0-6e8e-4adc-aa1c-bde1e081764d.png"> |
| table | <img width="1011" alt="Screen Shot 2023-02-03 at 2 03 34 PM" src="https://user-images.githubusercontent.com/458784/216724920-80f38b67-008a-458f-a848-ec62bb5a9c59.png"> |

