### PR TITLE
Update daily registrations table view: one row per day

### DIFF
--- a/src/components/daily-registrations-report.test.tsx
+++ b/src/components/daily-registrations-report.test.tsx
@@ -30,14 +30,18 @@ describe("DailyRegistrationsReport", () => {
       const table = tabulate(results);
 
       expect(table).to.deep.equal({
-        header: ["", "2020-01-01", "2020-01-02"],
+        header: [
+          "Date",
+          "New Users",
+          "New Fully Registered Users",
+          "Deleted Users",
+          "Cumulative Users",
+          "Cumulative Fully Registered Users",
+          "Cumulative Deleted Users",
+        ],
         body: [
-          ["New Users", 5, 6],
-          ["New Fully Registered Users", 1, 2],
-          ["Deleted Users", 3, 4],
-          ["Cumulative Users", 10, 17],
-          ["Cumulative Fully Registered Users", 2, 4],
-          ["Cumulative Deleted Users", 5, 9],
+          ["2020-01-02", 6, 2, 4, 17, 4, 9],
+          ["2020-01-01", 5, 1, 3, 10, 2, 5],
         ],
       });
     });

--- a/src/components/daily-registrations-report.tsx
+++ b/src/components/daily-registrations-report.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "preact-fetching";
 import { useRef, useState, useContext } from "preact/hooks";
 import * as Plot from "@observablehq/plot";
 import Markdown from "preact-markdown";
+import { descending } from "d3-array";
 import { ReportFilterContext } from "../contexts/report-filter-context";
 import useResizeListener from "../hooks/resize-listener";
 import {
@@ -60,24 +61,36 @@ function plot({ data, width }: { data: ProcessedRenderableData[]; width?: number
  */
 function tabulate(results: ProcessedResult[]): TableData {
   return {
-    header: ["", ...results.map(({ date }) => yearMonthDayFormat(date))],
-    body: [
-      ["New Users", ...results.map(({ totalUsers }) => totalUsers)],
-      [
-        "New Fully Registered Users",
-        ...results.map(({ fullyRegisteredUsers }) => fullyRegisteredUsers),
-      ],
-      ["Deleted Users", ...results.map(({ deletedUsers }) => deletedUsers)],
-      ["Cumulative Users", ...results.map(({ totalUsersCumulative }) => totalUsersCumulative)],
-      [
-        "Cumulative Fully Registered Users",
-        ...results.map(({ fullyRegisteredUsersCumulative }) => fullyRegisteredUsersCumulative),
-      ],
-      [
-        "Cumulative Deleted Users",
-        ...results.map(({ deletedUsersCumulative }) => deletedUsersCumulative),
-      ],
+    header: [
+      "Date",
+      "New Users",
+      "New Fully Registered Users",
+      "Deleted Users",
+      "Cumulative Users",
+      "Cumulative Fully Registered Users",
+      "Cumulative Deleted Users",
     ],
+    body: results
+      .sort(({ date: aDate }, { date: bDate }) => descending(aDate, bDate))
+      .map(
+        ({
+          date,
+          totalUsers,
+          fullyRegisteredUsers,
+          deletedUsers,
+          totalUsersCumulative,
+          fullyRegisteredUsersCumulative,
+          deletedUsersCumulative,
+        }) => [
+          yearMonthDayFormat(date),
+          totalUsers,
+          fullyRegisteredUsers,
+          deletedUsers,
+          totalUsersCumulative,
+          fullyRegisteredUsersCumulative,
+          deletedUsersCumulative,
+        ]
+      ),
   };
 }
 


### PR DESCRIPTION
**Why**: makes for less horizontal scrolling when viewing a longer range of time


| before | after |
| --- | --- |
| <img width="1000" alt="Screen Shot 2023-02-06 at 12 53 45 PM" src="https://user-images.githubusercontent.com/458784/217083580-7ab6784a-575b-4dc2-8e15-04fb10771304.png"> | <img width="993" alt="Screen Shot 2023-02-06 at 12 53 51 PM" src="https://user-images.githubusercontent.com/458784/217083578-56e67d91-1963-4659-92ab-3a28a33141a7.png"> |

