### PR TITLE
Hide misleading proofing reports

### DIFF
--- a/src/components/daily-dropoffs-report.tsx
+++ b/src/components/daily-dropoffs-report.tsx
@@ -1,5 +1,5 @@
 import { VNode } from "preact";
-import { useContext, useRef, useState } from "preact/hooks";
+import { useContext, useRef } from "preact/hooks";
 import { useQuery } from "preact-fetching";
 import { scaleLinear, scaleOrdinal } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
@@ -9,8 +9,6 @@ import { FunnelMode, ReportFilterContext } from "../contexts/report-filter-conte
 import Table, { TableData } from "./table";
 import { useAgencies } from "../contexts/agencies-context";
 import Accordion from "./accordion";
-import useResizeListener from "../hooks/resize-listener";
-import DailyDropoffsLineChart from "./daily-dropoffs-line-chart";
 import {
   DailyDropoffsRow,
   funnelSteps,
@@ -112,9 +110,7 @@ function tabulate({
 
 function DailyDropffsReport(): VNode {
   const ref = useRef(null as HTMLDivElement | null);
-  const [width, setWidth] = useState(undefined as number | undefined);
-  const { byAgency, start, finish, agency, env, funnelMode, scale } =
-    useContext(ReportFilterContext);
+  const { byAgency, start, finish, agency, env, funnelMode } = useContext(ReportFilterContext);
 
   const { data } = useQuery(`dropoffs/${start.valueOf()}-${finish.valueOf()}`, () =>
     loadData(start, finish, env)
@@ -122,7 +118,6 @@ function DailyDropffsReport(): VNode {
 
   const issuerColor = scaleOrdinal(schemeCategory10);
 
-  useResizeListener(() => setWidth(ref.current?.offsetWidth));
   useAgencies(data);
 
   const nonNullData = aggregate(data || []);
@@ -145,13 +140,6 @@ The data model table can't accurately capture:
 `}
         />
       </Accordion>
-      <DailyDropoffsLineChart
-        data={filteredData}
-        width={width}
-        color={issuerColor}
-        funnelMode={funnelMode}
-        scale={scale}
-      />
       <Table
         data={tabulate({ rows: filteredData, issuerColor, funnelMode })}
         numberFormatter={formatWithCommas}

--- a/src/components/daily-dropoffs-report.tsx
+++ b/src/components/daily-dropoffs-report.tsx
@@ -1,14 +1,11 @@
 import { VNode } from "preact";
 import { scaleLinear } from "d3-scale";
 import { ascending } from "d3-array";
+import Markdown from "preact-markdown";
 import { FunnelMode } from "../contexts/report-filter-context";
 import { TableData } from "./table";
-import {
-  DailyDropoffsRow,
-  funnelSteps,
-  toStepCounts,
-} from "../models/daily-dropoffs-report-data";
-import { formatAsPercent, formatWithCommas, yearMonthDayFormat } from "../formats";
+import { DailyDropoffsRow, funnelSteps, toStepCounts } from "../models/daily-dropoffs-report-data";
+import { formatAsPercent, formatWithCommas } from "../formats";
 
 function tabulate({
   rows: unsortedRows,
@@ -101,9 +98,14 @@ function tabulate({
 
 function DailyDropffsReport(): VNode {
   return (
-    <div class="padding-bottom-5">
-      <h2>This Report is Unavailable Right Now</h2>
-      <p>We're investigating inconsistencies in the underlying data.</p>
+    <div className="padding-bottom-5">
+      <Markdown
+        markdown={`
+## This Report is Unavailable Right Now
+
+We're investigating inconsistencies in the underlying data.
+`}
+      />
     </div>
   );
 }

--- a/src/components/daily-dropoffs-report.tsx
+++ b/src/components/daily-dropoffs-report.tsx
@@ -1,5 +1,5 @@
 import { VNode } from "preact";
-import { useContext, useRef } from "preact/hooks";
+import { useContext, useRef, useState } from "preact/hooks";
 import { useQuery } from "preact-fetching";
 import { scaleLinear, scaleOrdinal } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
@@ -9,6 +9,8 @@ import { FunnelMode, ReportFilterContext } from "../contexts/report-filter-conte
 import Table, { TableData } from "./table";
 import { useAgencies } from "../contexts/agencies-context";
 import Accordion from "./accordion";
+import useResizeListener from "../hooks/resize-listener";
+import DailyDropoffsLineChart from "./daily-dropoffs-line-chart";
 import {
   DailyDropoffsRow,
   funnelSteps,
@@ -110,7 +112,9 @@ function tabulate({
 
 function DailyDropffsReport(): VNode {
   const ref = useRef(null as HTMLDivElement | null);
-  const { byAgency, start, finish, agency, env, funnelMode } = useContext(ReportFilterContext);
+  const [width, setWidth] = useState(undefined as number | undefined);
+  const { byAgency, start, finish, agency, env, funnelMode, scale } =
+    useContext(ReportFilterContext);
 
   const { data } = useQuery(`dropoffs/${start.valueOf()}-${finish.valueOf()}`, () =>
     loadData(start, finish, env)
@@ -118,6 +122,7 @@ function DailyDropffsReport(): VNode {
 
   const issuerColor = scaleOrdinal(schemeCategory10);
 
+  useResizeListener(() => setWidth(ref.current?.offsetWidth));
   useAgencies(data);
 
   const nonNullData = aggregate(data || []);
@@ -140,6 +145,15 @@ The data model table can't accurately capture:
 `}
         />
       </Accordion>
+      {undefined && (
+        <DailyDropoffsLineChart
+          data={filteredData}
+          width={width}
+          color={issuerColor}
+          funnelMode={funnelMode}
+          scale={scale}
+        />
+      )}
       <Table
         data={tabulate({ rows: filteredData, issuerColor, funnelMode })}
         numberFormatter={formatWithCommas}

--- a/src/components/daily-dropoffs-report.tsx
+++ b/src/components/daily-dropoffs-report.tsx
@@ -1,23 +1,12 @@
 import { VNode } from "preact";
-import { useContext, useRef, useState } from "preact/hooks";
-import { useQuery } from "preact-fetching";
-import { scaleLinear, scaleOrdinal } from "d3-scale";
-import { schemeCategory10 } from "d3-scale-chromatic";
-import Markdown from "preact-markdown";
+import { scaleLinear } from "d3-scale";
 import { ascending } from "d3-array";
-import { FunnelMode, ReportFilterContext } from "../contexts/report-filter-context";
-import Table, { TableData } from "./table";
-import { useAgencies } from "../contexts/agencies-context";
-import Accordion from "./accordion";
-import useResizeListener from "../hooks/resize-listener";
-import DailyDropoffsLineChart from "./daily-dropoffs-line-chart";
+import { FunnelMode } from "../contexts/report-filter-context";
+import { TableData } from "./table";
 import {
   DailyDropoffsRow,
   funnelSteps,
-  loadData,
   toStepCounts,
-  aggregateAll,
-  aggregate,
 } from "../models/daily-dropoffs-report-data";
 import { formatAsPercent, formatWithCommas, yearMonthDayFormat } from "../formats";
 
@@ -111,56 +100,10 @@ function tabulate({
 }
 
 function DailyDropffsReport(): VNode {
-  const ref = useRef(null as HTMLDivElement | null);
-  const [width, setWidth] = useState(undefined as number | undefined);
-  const { byAgency, start, finish, agency, env, funnelMode, scale } =
-    useContext(ReportFilterContext);
-
-  const { data } = useQuery(`dropoffs/${start.valueOf()}-${finish.valueOf()}`, () =>
-    loadData(start, finish, env)
-  );
-
-  const issuerColor = scaleOrdinal(schemeCategory10);
-
-  useResizeListener(() => setWidth(ref.current?.offsetWidth));
-  useAgencies(data);
-
-  const nonNullData = aggregate(data || []);
-  const filteredData = (byAgency ? nonNullData : aggregateAll(nonNullData)).filter(
-    (d) => !agency || d.agency === agency
-  );
-
   return (
-    <div ref={ref}>
-      <Accordion title="How is this measured?">
-        <Markdown
-          markdown={`
-**Timing**: All data is collected, grouped, and displayed in the UTC timezone.
-
-**Known Limitations**:
-
-The data model table can't accurately capture:
-- Users who become verified on a different day than the day they start proofing (such as verify by mail)
-- Users who attempt proofing at one partner app, and reattempt with a different partner app.
-`}
-        />
-      </Accordion>
-      {undefined && (
-        <DailyDropoffsLineChart
-          data={filteredData}
-          width={width}
-          color={issuerColor}
-          funnelMode={funnelMode}
-          scale={scale}
-        />
-      )}
-      <Table
-        data={tabulate({ rows: filteredData, issuerColor, funnelMode })}
-        numberFormatter={formatWithCommas}
-        filename={`daily-dropoffs-report-${yearMonthDayFormat(start)}-to-${yearMonthDayFormat(
-          finish
-        )}.csv`}
-      />
+    <div class="padding-bottom-5">
+      <h2>This Report is Unavailable Right Now</h2>
+      <p>We're investigating inconsistencies in the underlying data.</p>
     </div>
   );
 }

--- a/src/components/proofing-over-time-report.tsx
+++ b/src/components/proofing-over-time-report.tsx
@@ -252,6 +252,7 @@ export default function ProofingOverTimeReport(): VNode {
     scale,
     byAgency,
     timeBucket = TimeBucket.WEEK,
+    extra,
   } = useContext(ReportFilterContext);
 
   const { data } = useQuery(`proofing-over-time-${start.valueOf()}-${finish.valueOf()}`, () =>
@@ -300,86 +301,89 @@ The data model table can't accurately capture:
 - Users who attempt proofing at one partner app, and reattempt with a different partner app.`}
         />
       </Accordion>
-      <PlotComponent
-        plotter={() =>
-          Plot.plot({
-            y: {
-              tickFormat,
-              domain: scale === Scale.PERCENT ? [0, 1] : undefined,
-              label: "↑ Verified",
-            },
-            color: {
-              legend: true,
-            },
-            marginRight: 50,
-            width,
-            marks: [
-              Plot.ruleY([0]),
-              Plot.lineY(
-                flatSteps,
-                Plot.binX(
-                  { y: scale === Scale.PERCENT ? "mean" : "sum" },
-                  {
-                    x: "date",
-                    y,
-                    thresholds,
-                    z: lineDeterminer,
-                    stroke,
-                    title: lineDeterminer,
-                    filter,
-                  }
-                )
-              ),
-              showAverages &&
-                Plot.ruleY(
+      {extra && (
+        <PlotComponent
+          plotter={() =>
+            Plot.plot({
+              y: {
+                tickFormat,
+                domain: scale === Scale.PERCENT ? [0, 1] : undefined,
+                label: "↑ Verified",
+              },
+              color: {
+                legend: true,
+              },
+              marginRight: 50,
+              width,
+              marks: [
+                Plot.ruleY([0]),
+                Plot.lineY(
+
                   flatSteps,
-                  Plot.binY(
-                    { y: "mean" },
+                  Plot.binX(
+                    { y: scale === Scale.PERCENT ? "mean" : "sum" },
                     {
+                      x: "date",
+                      y,
+                      thresholds,
                       z: lineDeterminer,
                       stroke,
-                      strokeDasharray: "3,2",
-                      thresholds,
-                      y,
+                      title: lineDeterminer,
                       filter,
                     }
                   )
                 ),
-              showAverages &&
-                Plot.text(
-                  flatSteps,
-                  Plot.binY(
-                    { y: "mean" },
-                    {
-                      y,
-                      text: (bin: StepCountEntry[]) => tickFormat(mean(bin, (d) => d[y]) || 0),
-                      x:
-                        timeBucket === TimeBucket.WEEK
-                          ? mean([thresholds.floor(finish), thresholds.ceil(finish)])
-                          : finish,
-                      dx: timeBucket === TimeBucket.DAY ? 15 : undefined,
-                      z: lineDeterminer,
-                      fill: stroke,
-                      thresholds,
-                      textAnchor: "start",
-                      filter,
-                    }
-                  )
-                ),
-            ].filter(Boolean),
-          })
-        }
-        inputs={[
-          flatSteps,
-          agency,
-          start.valueOf(),
-          finish.valueOf(),
-          width,
-          funnelMode,
-          scale,
-          timeBucket,
-        ]}
-      />
+                showAverages &&
+                  Plot.ruleY(
+                    flatSteps,
+                    Plot.binY(
+                      { y: "mean" },
+                      {
+                        z: lineDeterminer,
+                        stroke,
+                        strokeDasharray: "3,2",
+                        thresholds,
+                        y,
+                        filter,
+                      }
+                    )
+                  ),
+                showAverages &&
+                  Plot.text(
+                    flatSteps,
+                    Plot.binY(
+                      { y: "mean" },
+                      {
+                        y,
+                        text: (bin: StepCountEntry[]) => tickFormat(mean(bin, (d) => d[y]) || 0),
+                        x:
+                          timeBucket === TimeBucket.WEEK
+                            ? mean([thresholds.floor(finish), thresholds.ceil(finish)])
+                            : finish,
+                        dx: timeBucket === TimeBucket.DAY ? 15 : undefined,
+                        z: lineDeterminer,
+                        fill: stroke,
+                        thresholds,
+                        textAnchor: "start",
+                        filter,
+                      }
+                    )
+                  ),
+              ].filter(Boolean),
+            })
+          }
+          inputs={[
+            flatSteps,
+            agency,
+            start.valueOf(),
+            finish.valueOf(),
+            width,
+            funnelMode,
+            scale,
+            timeBucket,
+          ]}
+        />
+      )}
       {!byAgency && (
         <Table
           data={tabulateAll({
@@ -395,17 +399,17 @@ The data model table can't accurately capture:
       {byAgency && !agency && (
         <Table
           data={tabulateByAgency({ data: filteredData, timeBucket, funnelMode, color })}
-          filename={`proofing-over-time-report-agencies-${yearMonthDayFormat(start)}-to-${yearMonthDayFormat(
-            finish
-          )}.csv`}
+          filename={`proofing-over-time-report-agencies-${yearMonthDayFormat(
+            start
+          )}-to-${yearMonthDayFormat(finish)}.csv`}
         />
       )}
       {byAgency && agency && (
         <Table
           data={tabulateByIssuer({ data: filteredData, timeBucket, funnelMode, color })}
-          filename={`proofing-over-time-report-${kebabCase(agency)}-${yearMonthDayFormat(start)}-to-${yearMonthDayFormat(
-            finish
-          )}.csv`}
+          filename={`proofing-over-time-report-${kebabCase(agency)}-${yearMonthDayFormat(
+            start
+          )}-to-${yearMonthDayFormat(finish)}.csv`}
         />
       )}
     </div>


### PR DESCRIPTION
**Why**: The graphs are misleading at the moment so this helps us reduce confusion.

See [slack thread for context](https://gsa-tts.slack.com/archives/C01541F40SW/p1675777991411129)

| screenshot |
| --- |
|  <img width="1045" alt="Screen Shot 2023-02-07 at 10 08 14 AM" src="https://user-images.githubusercontent.com/458784/217329960-19d2512e-362d-42b1-8351-345159f900a8.png"> |

