### PR TITLE
Fix full path helper for preview environments

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -5,7 +5,7 @@ describe("router", () => {
   describe("#getFullPath", () => {
     it("prepends the base path to the path", () => {
       const path = "/foobar.html";
-      const basePath = "/some/nested/directory/";
+      const basePath = "/some/nested/directory";
       expect(getFullPath(path, basePath)).to.eq("/some/nested/directory/foobar.html");
     });
 
@@ -17,13 +17,13 @@ describe("router", () => {
 
     it("does not add the base path when it is already there", () => {
       const path = "/some/prefix/foo/bar.html";
-      const basePath = "/some/prefix/";
+      const basePath = "/some/prefix";
       expect(getFullPath(path, basePath)).to.eq(path);
     });
 
     it("does not remove a trailing slash", () => {
       const path = "/foo/";
-      const basePath = "/some/prefix/";
+      const basePath = "/some/prefix";
       expect(getFullPath(path, basePath)).to.eq("/some/prefix/foo/");
     });
   });

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,7 +13,7 @@ interface RouterProps {
 const { BASE_URL = "" } = import.meta.env ?? {};
 
 export const getFullPath = (path = "", basePath = BASE_URL): string =>
-  path.startsWith(basePath) ? path : basePath + path.replace(/^\//, "");
+  path.startsWith(basePath) ? path : basePath + path;
 
 export function Router({ children }: RouterProps): VNode {
   const childrenAsArray = toChildArray(children) as VNode<RoutableProps>[];


### PR DESCRIPTION
BASE_URL in preview environments does not include a trailing slash, so avoid trimming the leading slash from the given path.

**Testing Instructions:**

1. Go to https://federalist-14721e0a-0772-4dcd-b62f-ee9d20dcc5fd.sites.pages.cloud.gov/preview/18f/identity-reporting/aduth-fix-preview-links/
2. Click a link in the navigation
3. Refresh the page

Before: 404
After: Current page is shown after refresh