### PR TITLE
Set default port for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Summary reports of login.gov activity
 
 ```bash
 npm install
-npm run dev
+npm start
 ```
 
 View the application at http://localhost:3000/

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
   "scripts": {
     "build": "vite build",
     "postbuild": "npm run generate-routes && cp robots.txt _site/",
-    "dev": "vite --port ${PORT:-3000}",
     "generate-routes": "node -r esbuild-register bin/generate-routes.js",
     "pages": "npm run build -- --base=${BASEURL:-/}",
     "prettier:fix": "npm run test:lint -- --fix",
-    "serve": "vite preview --port ${PORT:-3000}",
+    "start": "vite --port ${PORT:-3000}",
     "test:lint": "eslint . --ext .js,.ts,.tsx",
     "test:typecheck": "tsc",
     "test:unit": "mocha -r esbuild-register -r global-jsdom/register -r ./mocha-setup.ts 'src/**/*.test.{js,ts,tsx}'",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "scripts": {
     "build": "vite build",
     "postbuild": "npm run generate-routes && cp robots.txt _site/",
-    "dev": "vite",
+    "dev": "vite --port ${PORT:-3000}",
     "generate-routes": "node -r esbuild-register bin/generate-routes.js",
     "pages": "npm run build -- --base=${BASEURL:-/}",
     "prettier:fix": "npm run test:lint -- --fix",
-    "serve": "vite preview",
+    "serve": "vite preview --port ${PORT:-3000}",
     "test:lint": "eslint . --ext .js,.ts,.tsx",
     "test:typecheck": "tsc",
     "test:unit": "mocha -r esbuild-register -r global-jsdom/register -r ./mocha-setup.ts 'src/**/*.test.{js,ts,tsx}'",


### PR DESCRIPTION
**Why**: Works better with our CDN

this is what we have [in our config](https://github.com/18F/identity-devops/blob/e4818146d278bdc297901cf2d17d2da6362d28c6/terraform/app/bucket-public-reporting-data.tf#L73)