### PR TITLE
Add mocharc file for common Mocha configuration

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  require: ["esbuild-register", "global-jsdom/register"],
+  file: "./mocha-setup.ts",
+  extension: ["js", "jsx", "ts", "tsx"],
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "serve": "vite preview",
     "test:lint": "eslint . --ext .js,.ts,.tsx",
     "test:typecheck": "tsc",
-    "test:unit": "mocha -r esbuild-register -r global-jsdom/register -r ./mocha-setup.ts 'src/**/*.test.{js,ts,tsx}'",
+    "test:unit": "mocha 'src/**/*.test.{js,ts,tsx}'",
     "test": "run-p test:*"
   },
   "dependencies": {


### PR DESCRIPTION
**Why**: To facilitate using the Mocha command line utility directly, e.g. when running a single test file.

```
npm exec mocha src/components/daily-auths-report.test.ts
```